### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ generates:
 
 type: `string`
 
-import types from generated typescript type path. if not given, omit import statement.
+When provided, import types from the generated typescript types file path. if not given, omit import statement.
 
 ```yml
 generates:


### PR DESCRIPTION
Hi @Code-Hex,

I'm Charly for The Guild, thank you again for your awesome plugin! ✨ 

I made the following change proposal in the attempt to fix the documentation issues on our side:

https://github.com/dotansimha/graphql-code-generator/pull/7438

In short, our plugin hub system is parsing each plugin `README.md` as `MDX`.
The documentation generation (with Vercel/Next.js) fails with your plugin because of the following sentence in your `README.md`:

> import types from generated typescript [...]

is identified by `MDX` as an invalid JS import expression...

I'm aware that the issue should be fixed on our side but it would be way faster to fix it this way 🏎️ 

Let me know what you think.
