### PR TITLE
added notAllowEmptyString option in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ type: `boolean` default: `false`
 
 Generates enum as TypeScript `type` instead of `enum`.
 
+### `notAllowEmptyString`
+
+type: `boolean` default: `false`
+
+Generates validation string schema as do not allow empty characters by default.
+
 ### `directives`
 
 type: `DirectiveConfig`

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,7 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    *       notAllowEmptyString: true
    * ```
    */
-   notAllowEmptyString?: boolean;
+  notAllowEmptyString?: boolean;
   /**
    * @description Generates validation schema with more API based on directive schema.
    * @exampleMarkdown

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,21 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    */
   enumsAsTypes?: boolean;
   /**
+   * @description Generates validation string schema as do not allow empty characters by default.
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/file.ts:
+   *     plugins:
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       notAllowEmptyString: true
+   * ```
+   */
+   notAllowEmptyString?: boolean;
+  /**
    * @description Generates validation schema with more API based on directive schema.
    * @exampleMarkdown
    * ```yml

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -116,6 +116,10 @@ const generateInputObjectFieldTypeZodSchema = (
   if (isNamedType(type)) {
     const gen = generateNameNodeZodSchema(tsVisitor, schema, type.name);
     if (isNonNullType(parentType)) {
+      if (config.notAllowEmptyString === true) {
+        const tsType = tsVisitor.scalars[type.name.value];
+        if (tsType === 'string') return `${gen}.min(1)`
+      }
       return gen;
     }
     if (isListType(parentType)) {

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -118,7 +118,7 @@ const generateInputObjectFieldTypeZodSchema = (
     if (isNonNullType(parentType)) {
       if (config.notAllowEmptyString === true) {
         const tsType = tsVisitor.scalars[type.name.value];
-        if (tsType === 'string') return `${gen}.min(1)`
+        if (tsType === 'string') return `${gen}.min(1)`;
       }
       return gen;
     }

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -238,7 +238,7 @@ describe('yup', () => {
       'c: yup.boolean().defined(),',
       'd: yup.number().defined(),',
       'e: yup.number().defined()',
-    ]
+    ];
     for (const wantContain of wantContains) {
       expect(result.content).toContain(wantContain);
     }

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -212,4 +212,35 @@ describe('yup', () => {
     );
     expect(result.content).toContain("export const PageTypeSchema = yup.mixed().oneOf(['PUBLIC', 'BASIC_AUTH'])");
   });
+
+  it('with notAllowEmptyString', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input PrimitiveInput {
+        a: ID!
+        b: String!
+        c: Boolean!
+        d: Int!
+        e: Float!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        notAllowEmptyString: true,
+      },
+      {}
+    );
+    const wantContains = [
+      'export function PrimitiveInputSchema(): yup.SchemaOf<PrimitiveInput>',
+      'a: yup.string().required(),',
+      'b: yup.string().required(),',
+      'c: yup.boolean().defined(),',
+      'd: yup.number().defined(),',
+      'e: yup.number().defined()',
+    ]
+    for (const wantContain of wantContains) {
+      expect(result.content).toContain(wantContain);
+    }
+  });
 });

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -215,4 +215,36 @@ describe('zod', () => {
     );
     expect(result.content).toContain("export const PageTypeSchema = z.enum(['PUBLIC', 'BASIC_AUTH'])");
   });
+
+  it('with notAllowEmptyString', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input PrimitiveInput {
+        a: ID!
+        b: String!
+        c: Boolean!
+        d: Int!
+        e: Float!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'zod',
+        notAllowEmptyString: true,
+      },
+      {}
+    );
+    const wantContains = [
+      'export function PrimitiveInputSchema(): z.ZodSchema<PrimitiveInput>',
+      'a: z.string().min(1),',
+      'b: z.string().min(1),',
+      'c: z.boolean(),',
+      'd: z.number(),',
+      'e: z.number()',
+    ];
+    for (const wantContain of wantContains) {
+      expect(result.content).toContain(wantContain);
+    }
+  });
 });


### PR DESCRIPTION
Related: #12 

The currently generated schema allows for empty characters.

However, there is a use case where we want to generate a schema that does not allow empty characters, so I support that.