### PR TITLE
fixed return type to be z.ZodObject

### DIFF
--- a/example/zod/schemas.ts
+++ b/example/zod/schemas.ts
@@ -1,13 +1,17 @@
 import { z } from 'zod'
 import { AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, HttpInput, HttpMethod, LayoutInput, PageInput, PageType } from '../types'
 
+type Properties<T> = Required<{
+  [K in keyof T]: z.ZodType<T[K], any, T[K]>;
+}>;
+
 type definedNonNullAny = {};
 
 export const isDefinedNonNullAny = (v: any): v is definedNonNullAny => v !== undefined && v !== null;
 
-export const definedNonNullAnySchema: z.ZodSchema<definedNonNullAny> = z.any().refine((v) => isDefinedNonNullAny(v));
+export const definedNonNullAnySchema = z.any().refine((v) => isDefinedNonNullAny(v));
 
-export function AttributeInputSchema(): z.ZodSchema<AttributeInput> {
+export function AttributeInputSchema(): z.ZodObject<Properties<AttributeInput>> {
   return z.object({
     key: z.string().nullish(),
     val: z.string().nullish()
@@ -16,7 +20,7 @@ export function AttributeInputSchema(): z.ZodSchema<AttributeInput> {
 
 export const ButtonComponentTypeSchema = z.nativeEnum(ButtonComponentType);
 
-export function ComponentInputSchema(): z.ZodSchema<ComponentInput> {
+export function ComponentInputSchema(): z.ZodObject<Properties<ComponentInput>> {
   return z.object({
     child: z.lazy(() => ComponentInputSchema().nullish()),
     childrens: z.array(z.lazy(() => ComponentInputSchema().nullable())).nullish(),
@@ -26,21 +30,21 @@ export function ComponentInputSchema(): z.ZodSchema<ComponentInput> {
   })
 }
 
-export function DropDownComponentInputSchema(): z.ZodSchema<DropDownComponentInput> {
+export function DropDownComponentInputSchema(): z.ZodObject<Properties<DropDownComponentInput>> {
   return z.object({
     dropdownComponent: z.lazy(() => ComponentInputSchema().nullish()),
     getEvent: z.lazy(() => EventInputSchema())
   })
 }
 
-export function EventArgumentInputSchema(): z.ZodSchema<EventArgumentInput> {
+export function EventArgumentInputSchema(): z.ZodObject<Properties<EventArgumentInput>> {
   return z.object({
     name: z.string().min(5),
     value: z.string().regex(/^foo/, "message")
   })
 }
 
-export function EventInputSchema(): z.ZodSchema<EventInput> {
+export function EventInputSchema(): z.ZodObject<Properties<EventInput>> {
   return z.object({
     arguments: z.array(z.lazy(() => EventArgumentInputSchema())),
     options: z.array(EventOptionTypeSchema).nullish()
@@ -49,7 +53,7 @@ export function EventInputSchema(): z.ZodSchema<EventInput> {
 
 export const EventOptionTypeSchema = z.nativeEnum(EventOptionType);
 
-export function HttpInputSchema(): z.ZodSchema<HttpInput> {
+export function HttpInputSchema(): z.ZodObject<Properties<HttpInput>> {
   return z.object({
     method: HttpMethodSchema.nullish(),
     url: definedNonNullAnySchema
@@ -58,13 +62,13 @@ export function HttpInputSchema(): z.ZodSchema<HttpInput> {
 
 export const HttpMethodSchema = z.nativeEnum(HttpMethod);
 
-export function LayoutInputSchema(): z.ZodSchema<LayoutInput> {
+export function LayoutInputSchema(): z.ZodObject<Properties<LayoutInput>> {
   return z.object({
     dropdown: z.lazy(() => DropDownComponentInputSchema().nullish())
   })
 }
 
-export function PageInputSchema(): z.ZodSchema<PageInput> {
+export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
   return z.object({
     attributes: z.array(z.lazy(() => AttributeInputSchema())).nullish(),
     date: definedNonNullAnySchema.nullish(),

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -30,6 +30,11 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
     initialEmit: (): string =>
       '\n' +
       [
+        new DeclarationBlock({}).asKind('type').withName('Properties<T>').withContent([
+          'Required<{',
+          '  [K in keyof T]: z.ZodType<T[K], any, T[K]>;',
+          '}>',
+        ].join('\n')).string,
         // Unfortunately, zod doesn’t provide non-null defined any schema.
         // This is a temporary hack until it is fixed.
         // see: https://github.com/colinhacks/zod/issues/884
@@ -42,7 +47,7 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
         new DeclarationBlock({})
           .export()
           .asKind('const')
-          .withName(`${anySchema}: z.ZodSchema<definedNonNullAny>`)
+          .withName(`${anySchema}`)
           .withContent(`z.any().refine((v) => isDefinedNonNullAny(v))`).string,
       ].join('\n'),
     InputObjectTypeDefinition: (node: InputObjectTypeDefinitionNode) => {
@@ -56,7 +61,7 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
       return new DeclarationBlock({})
         .export()
         .asKind('function')
-        .withName(`${name}Schema(): z.ZodSchema<${name}>`)
+        .withName(`${name}Schema(): z.ZodObject<Properties<${name}>>`)
         .withBlock([indent(`return z.object({`), shape, indent('})')].join('\n')).string;
     },
     EnumTypeDefinition: (node: EnumTypeDefinitionNode) => {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -15,7 +15,7 @@ describe('zod', () => {
         }
       `,
       [
-        'export function PrimitiveInputSchema(): z.ZodSchema<PrimitiveInput>',
+        'export function PrimitiveInputSchema(): z.ZodObject<Properties<PrimitiveInput>>',
         'a: z.string()',
         'b: z.string()',
         'c: z.boolean()',
@@ -36,7 +36,7 @@ describe('zod', () => {
         }
       `,
       [
-        'export function PrimitiveInputSchema(): z.ZodSchema<PrimitiveInput>',
+        'export function PrimitiveInputSchema(): z.ZodObject<Properties<PrimitiveInput>>',
         // alphabet order
         'a: z.string().nullish(),',
         'b: z.string().nullish(),',
@@ -58,7 +58,7 @@ describe('zod', () => {
         }
       `,
       [
-        'export function ArrayInputSchema(): z.ZodSchema<ArrayInput>',
+        'export function ArrayInputSchema(): z.ZodObject<Properties<ArrayInput>>',
         'a: z.array(z.string().nullable()).nullish(),',
         'b: z.array(z.string()).nullish(),',
         'c: z.array(z.string()),',
@@ -81,11 +81,11 @@ describe('zod', () => {
         }
       `,
       [
-        'export function AInputSchema(): z.ZodSchema<AInput>',
+        'export function AInputSchema(): z.ZodObject<Properties<AInput>>',
         'b: z.lazy(() => BInputSchema())',
-        'export function BInputSchema(): z.ZodSchema<BInput>',
+        'export function BInputSchema(): z.ZodObject<Properties<BInput>>',
         'c: z.lazy(() => CInputSchema())',
-        'export function CInputSchema(): z.ZodSchema<CInput>',
+        'export function CInputSchema(): z.ZodObject<Properties<CInput>>',
         'a: z.lazy(() => AInputSchema())',
       ],
     ],
@@ -98,7 +98,7 @@ describe('zod', () => {
         }
       `,
       [
-        'export function NestedInputSchema(): z.ZodSchema<NestedInput>',
+        'export function NestedInputSchema(): z.ZodObject<Properties<NestedInput>>',
         'child: z.lazy(() => NestedInputSchema().nullish()),',
         'childrens: z.array(z.lazy(() => NestedInputSchema().nullable())).nullish()',
       ],
@@ -116,7 +116,7 @@ describe('zod', () => {
       `,
       [
         'export const PageTypeSchema = z.nativeEnum(PageType)',
-        'export function PageInputSchema(): z.ZodSchema<PageInput>',
+        'export function PageInputSchema(): z.ZodObject<Properties<PageInput>>',
         'pageType: PageTypeSchema',
       ],
     ],
@@ -136,7 +136,7 @@ describe('zod', () => {
         scalar URL # unknown scalar, should be any (definedNonNullAnySchema)
       `,
       [
-        'export function HttpInputSchema(): z.ZodSchema<HttpInput>',
+        'export function HttpInputSchema(): z.ZodObject<Properties<HttpInput>>',
         'export const HttpMethodSchema = z.nativeEnum(HttpMethod)',
         'method: HttpMethodSchema',
         'url: definedNonNullAnySchema',
@@ -236,7 +236,7 @@ describe('zod', () => {
       {}
     );
     const wantContains = [
-      'export function PrimitiveInputSchema(): z.ZodSchema<PrimitiveInput>',
+      'export function PrimitiveInputSchema(): z.ZodObject<Properties<PrimitiveInput>>',
       'a: z.string().min(1),',
       'b: z.string().min(1),',
       'c: z.boolean(),',
@@ -271,7 +271,7 @@ describe('zod', () => {
       {}
     );
     const wantContains = [
-      'export function ScalarsInputSchema(): z.ZodSchema<ScalarsInput>',
+      'export function ScalarsInputSchema(): z.ZodObject<Properties<ScalarsInput>>',
       'date: z.date(),',
       'email: z.string().email().nullish(),',
       'str: z.string()',


### PR DESCRIPTION
fix: https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/issues/21#issuecomment-1062035930

Applied good suggestion
https://github.com/colinhacks/zod/discussions/973#discussioncomment-2260618