### PR TITLE
Adding GraphQL `type` support to codegen

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -9,6 +9,7 @@ generates:
       - ./dist/main/index.js:
           schema: yup
           importFrom: ../types
+          useObjectTypes: true
           directives:
             required:
               msg: required
@@ -42,6 +43,7 @@ generates:
       - ./dist/main/index.js:
           schema: zod
           importFrom: ../types
+          useObjectTypes: true
           directives:
             # Write directives like
             #
@@ -62,6 +64,7 @@ generates:
       - ./dist/main/index.js:
           schema: myzod
           importFrom: ../types
+          useObjectTypes: true
           directives:
             constraint:
               minLength: min

--- a/example/myzod/schemas.ts
+++ b/example/myzod/schemas.ts
@@ -1,5 +1,5 @@
 import * as myzod from 'myzod'
-import { AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, HttpInput, HttpMethod, LayoutInput, PageInput, PageType } from '../types'
+import { AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User } from '../types'
 
 export const definedNonNullAnySchema = myzod.object({});
 
@@ -77,3 +77,15 @@ export function PageInputSchema(): myzod.Type<PageInput> {
 }
 
 export const PageTypeSchema = myzod.enum(PageType);
+
+export function UserSchema(): myzod.Type<User> {
+  return myzod.object({
+    __typename: myzod.literal('User').optional(),
+    createdAt: definedNonNullAnySchema.optional().nullable(),
+    email: myzod.string().optional().nullable(),
+    id: myzod.string().optional().nullable(),
+    name: myzod.string().optional().nullable(),
+    password: myzod.string().optional().nullable(),
+    updatedAt: definedNonNullAnySchema.optional().nullable()
+  })
+}

--- a/example/test.graphql
+++ b/example/test.graphql
@@ -5,6 +5,15 @@ enum PageType {
   BASIC_AUTH
 }
 
+type User {
+  id: ID
+  name: String
+  email: String
+  password: String
+  createdAt: Date
+  updatedAt: Date
+}
+
 input PageInput {
   id: ID!
   title: String!

--- a/example/types.ts
+++ b/example/types.ts
@@ -86,3 +86,13 @@ export enum PageType {
   Restricted = 'RESTRICTED',
   Service = 'SERVICE'
 }
+
+export type User = {
+  __typename?: 'User';
+  createdAt?: Maybe<Scalars['Date']>;
+  email?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
+  name?: Maybe<Scalars['String']>;
+  password?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['Date']>;
+};

--- a/example/yup/schemas.ts
+++ b/example/yup/schemas.ts
@@ -1,5 +1,5 @@
 import * as yup from 'yup'
-import { AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, HttpInput, HttpMethod, LayoutInput, PageInput, PageType } from '../types'
+import { AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User } from '../types'
 
 export function AttributeInputSchema(): yup.SchemaOf<AttributeInput> {
   return yup.object({
@@ -75,3 +75,15 @@ export function PageInputSchema(): yup.SchemaOf<PageInput> {
 }
 
 export const PageTypeSchema = yup.mixed().oneOf([PageType.BasicAuth, PageType.Lp, PageType.Restricted, PageType.Service]);
+
+export function UserSchema(): yup.SchemaOf<User> {
+  return yup.object({
+    __typename: yup.mixed().oneOf(['User', undefined]),
+    createdAt: yup.mixed(),
+    email: yup.string(),
+    id: yup.string(),
+    name: yup.string(),
+    password: yup.string(),
+    updatedAt: yup.mixed()
+  })
+}

--- a/example/zod/schemas.ts
+++ b/example/zod/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, HttpInput, HttpMethod, LayoutInput, PageInput, PageType } from '../types'
+import { AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User } from '../types'
 
 type Properties<T> = Required<{
   [K in keyof T]: z.ZodType<T[K], any, T[K]>;
@@ -85,3 +85,15 @@ export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
 }
 
 export const PageTypeSchema = z.nativeEnum(PageType);
+
+export function UserSchema(): z.ZodObject<Properties<User>> {
+  return z.object({
+    __typename: z.literal('User').optional(),
+    createdAt: definedNonNullAnySchema.nullish(),
+    email: z.string().nullish(),
+    id: z.string().nullish(),
+    name: z.string().nullish(),
+    password: z.string().nullish(),
+    updatedAt: definedNonNullAnySchema.nullish()
+  })
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    * @description import types from generated typescript type path
    * if not given, omit import statement.
    *
-   * @exampeMarkdown
+   * @exampleMarkdown
    * ```yml
    * generates:
    *   path/to/types.ts:
@@ -193,4 +193,22 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    * ```
    */
   directives?: DirectiveConfig;
+  /**
+   * @description Converts the regular graphql type into a zod validation function.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/types.ts:
+   *     plugins:
+   *       - typescript
+   *   path/to/schemas.ts:
+   *     plugins:
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       schema: yup
+   *       useObjectTypes: true
+   * ```
+   */
+  useObjectTypes?: boolean;
 }


### PR DESCRIPTION
This will allow the support of a schema with a type:

```graphql
type User {
  id: ID
  name: String
  email: String
  password: String
  createdAt: Date
  updatedAt: Date
}
```

to generate an expected validator

Yup: 
```typescript
export function UserSchema(): yup.SchemaOf<User> {
  return yup.object({
    __typename: yup.mixed().oneOf(['User', undefined]),
    createdAt: yup.mixed(),
    email: yup.string(),
    id: yup.string(),
    name: yup.string(),
    password: yup.string(),
    updatedAt: yup.mixed()
  })
}
```

Zod: 
```typescript
export function UserSchema(): z.ZodObject<Properties<User>> {
  return z.object({
    __typename: z.literal('User').optional(),
    createdAt: definedNonNullAnySchema.nullish(),
    email: z.string().nullish(),
    id: z.string().nullish(),
    name: z.string().nullish(),
    password: z.string().nullish(),
    updatedAt: definedNonNullAnySchema.nullish()
  })
}
```

MyZod: 
```typescript
export function UserSchema(): myzod.Type<User> {
  return myzod.object({
    __typename: myzod.literal('User').optional(),
    createdAt: definedNonNullAnySchema.optional().nullable(),
    email: myzod.string().optional().nullable(),
    id: myzod.string().optional().nullable(),
    name: myzod.string().optional().nullable(),
    password: myzod.string().optional().nullable(),
    updatedAt: definedNonNullAnySchema.optional().nullable()
  })
}

```