### PR TITLE
fix: ObjectTypeDefinitionBuilder greedy matching ignore types

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -14,7 +14,7 @@ export const ObjectTypeDefinitionBuilder = (
 ): ObjectTypeDefinitionFn | undefined => {
   if (!useObjectTypes) return undefined;
   return node => {
-    if (/^Query|Mutation|Subscription$/.test(node.name.value)) {
+    if (/^(Query|Mutation|Subscription)$/.test(node.name.value)) {
       return;
     }
     return callback(node);

--- a/tests/graphql.spec.ts
+++ b/tests/graphql.spec.ts
@@ -1,0 +1,46 @@
+import { Kind, ObjectTypeDefinitionNode } from 'graphql';
+import { ObjectTypeDefinitionBuilder } from '../src/graphql';
+
+describe('graphql', () => {
+  describe('ObjectTypeDefinitionBuilder', () => {
+    describe('useObjectTypes === true', () => {
+      test.each([
+        ['Query', false],
+        ['Mutation', false],
+        ['Subscription', false],
+        ['QueryFoo', true],
+        ['MutationFoo', true],
+        ['SubscriptionFoo', true],
+        ['FooQuery', true],
+        ['FooMutation', true],
+        ['FooSubscription', true],
+        ['Foo', true],
+      ])(`A node with a name of "%s" should be matched? %s`, (nodeName, nodeIsMatched) => {
+        const node: ObjectTypeDefinitionNode = {
+          name: {
+            kind: Kind.NAME,
+            value: nodeName,
+          },
+          kind: Kind.OBJECT_TYPE_DEFINITION,
+        };
+
+        const objectTypeDefFn = ObjectTypeDefinitionBuilder(true, (n: ObjectTypeDefinitionNode) => n);
+
+        expect(objectTypeDefFn).toBeDefined();
+
+        if (nodeIsMatched) {
+          expect(objectTypeDefFn?.(node)).toBe(node);
+        } else {
+          expect(objectTypeDefFn?.(node)).toBeUndefined();
+        }
+      });
+    });
+
+    describe('useObjectTypes === false', () => {
+      test('should not return an ObjectTypeDefinitionFn', () => {
+        const objectTypeDefFn = ObjectTypeDefinitionBuilder(false, (n: ObjectTypeDefinitionNode) => n);
+        expect(objectTypeDefFn).toBeUndefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
The Regex matcher for `ObjectTypeDefinitionBuilder` was greedy matching the ignore types.

Closes #167 