### PR TITLE
Support union types for zod generator

### DIFF
--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -9,6 +9,7 @@ import {
   ObjectTypeDefinitionNode,
   EnumTypeDefinitionNode,
   FieldDefinitionNode,
+  UnionTypeDefinitionNode,
 } from 'graphql';
 import { DeclarationBlock, indent } from '@graphql-codegen/visitor-plugin-common';
 import { TsVisitor } from '@graphql-codegen/typescript';
@@ -88,6 +89,18 @@ export const MyZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSche
         .asKind('const')
         .withName(`${enumname}Schema`)
         .withContent(`myzod.enum(${enumname})`).string;
+    },
+    UnionTypeDefinition: (node: UnionTypeDefinitionNode) => {
+      const unionName = tsVisitor.convertName(node.name.value);
+      const unionElements = node.types?.map(t => `${t.name.value}Schema()`).join(', ');
+
+      const result = new DeclarationBlock({})
+        .export()
+        .asKind('function')
+        .withName(`${unionName}Schema()`)
+        .withBlock(indent(`return myzod.union([${unionElements}])`));
+
+      return result.string;
     },
   };
 };

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -8,6 +8,7 @@ import {
   InputObjectTypeDefinitionNode,
   ObjectTypeDefinitionNode,
   EnumTypeDefinitionNode,
+  UnionTypeDefinitionNode,
   FieldDefinitionNode,
 } from 'graphql';
 import { DeclarationBlock, indent } from '@graphql-codegen/visitor-plugin-common';
@@ -99,6 +100,18 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
         .asKind('const')
         .withName(`${enumname}Schema`)
         .withContent(`z.nativeEnum(${enumname})`).string;
+    },
+    UnionTypeDefinition: (node: UnionTypeDefinitionNode) => {
+      const unionName = tsVisitor.convertName(node.name.value);
+      const unionElements = node.types?.map(t => `${t.name.value}Schema()`).join(', ');
+
+      const result = new DeclarationBlock({})
+        .export()
+        .asKind('function')
+        .withName(`${unionName}Schema()`)
+        .withBlock(indent(`return z.union([${unionElements}])`));
+
+      return result.string;
     },
   };
 };

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -538,6 +538,38 @@ describe('myzod', () => {
         expect(result.content).not.toContain(wantNotContain);
       }
     });
+
+    it('generate union types', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withObjectType: true,
+        },
+        {}
+      );
+
+      const wantContains = [
+        // Shape Schema
+        'export function ShapeSchema() {',
+        'myzod.union([CircleSchema(), SquareSchema()])',
+        '}',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
   });
 
   it('properly generates custom directive values', async () => {

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -570,6 +570,72 @@ describe('myzod', () => {
         expect(result.content).toContain(wantContain);
       }
     });
+
+    it('generate union types with single element', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+
+        type Geometry {
+          shape: Shape
+        }
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withObjectType: true,
+        },
+        {}
+      );
+
+      const wantContains = [
+        'export function GeometrySchema(): myzod.Type<Geometry> {',
+        'return myzod.object({',
+        "__typename: myzod.literal('Geometry').optional(),",
+        'shape: ShapeSchema().optional().nullable()',
+        '}',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
+
+    it('correctly reference generated union types', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withObjectType: true,
+        },
+        {}
+      );
+
+      const wantContains = [
+        // Shape Schema
+        'export function ShapeSchema() {',
+        'CircleSchema()',
+        '}',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
   });
 
   it('properly generates custom directive values', async () => {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -636,6 +636,37 @@ describe('zod', () => {
         expect(result.content).not.toContain(wantNotContain);
       }
     });
+
+    it('generate union types', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'zod',
+          withObjectType: true,
+        },
+        {}
+      );
+
+      const wantContains = [
+        // Shape Schema
+        'export function ShapeSchema() {',
+        'z.union([CircleSchema(), SquareSchema()])',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
   });
 
   it('properly generates custom directive values', async () => {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -662,6 +662,7 @@ describe('zod', () => {
         // Shape Schema
         'export function ShapeSchema() {',
         'z.union([CircleSchema(), SquareSchema()])',
+        '}',
       ];
       for (const wantContain of wantContains) {
         expect(result.content).toContain(wantContain);

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -696,10 +696,8 @@ describe('zod', () => {
 
       const wantContains = [
         'export function GeometrySchema(): z.ZodObject<Properties<Geometry>> {',
-        'return z.object({',
         "__typename: z.literal('Geometry').optional(),",
         'shape: ShapeSchema().nullish()',
-        '}',
       ];
       for (const wantContain of wantContains) {
         expect(result.content).toContain(wantContain);


### PR DESCRIPTION
Fixes #236 
Fixes #181 

This PR adds support for union types for generating zod schemas when `withObjectType` is enabled.