### PR TITLE
Add validation schema error message override

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,26 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    * ```
    */
   importFrom?: string;
+    /**
+   * @description Overrides default validation schema error messages.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/types.ts:
+   *     plugins:
+   *       - typescript
+   *   path/to/schemas.ts:
+   *     plugins:
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       schema: yup
+   *       errorMessage:
+   *         required: "This field is required"
+   *       importFrom: ./path/to/types
+   * ```
+   */
+  errorMessage?: Record<'required', string>;
   /**
    * @description Prefixes all import types from generated typescript type.
    * @default ""

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -238,11 +238,11 @@ const maybeNonEmptyString = (
     const maybeScalarName = childType.name.value;
     const tsType = tsVisitor.scalars[maybeScalarName];
     if (tsType === 'string') {
-      return `${schema}.required()`;
+      return `${schema}.required(${config.errorMessage?.required})`;
     }
   }
   // fallback
-  return `${schema}.defined()`;
+  return `${schema}.defined(${config.errorMessage?.required})`;
 };
 
 const yup4Scalar = (config: ValidationSchemaPluginConfig, tsVisitor: TsVisitor, scalarName: string): string => {


### PR DESCRIPTION
I'd like to be able to add a config option to override the default error message generated in a validation schema. This change adds this functionality for `yup`.

Please give any feedback or required next steps on this - thanks.