### PR TITLE
Fix ESM import

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "dist/main/index.js",
   "typings": "dist/main/index.d.ts",
-  "module": "dist/module/index.mjs",
+  "module": "dist/module/index.js",
   "files": [
     "dist/**/*.{js,ts}",
     "LICENSE",


### PR DESCRIPTION
Building an app with this dependency with Vite causes the following error:
`[vite:build-import-analysis] Failed to resolve entry for package "graphql-codegen-typescript-validation-schema". The package may have incorrect main/module/exports specified in its package.json.`

This is due to the `module` field being incorrectly defined, it should be `dist/module/index.js`