### PR TITLE
fix 373

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ generates:
       schema: yup # or zod
 ```
 
+It is recommended to write `scalars` config for built-in type `ID`, as in the yaml example shown above. For more information: [#375](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/pull/375)
+
 You can check [example](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/tree/main/example) directory if you want to see more complex config example or how is generated some files.
 
 The Q&A for each schema is written in the README in the respective example directory.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ generates:
       # You can put the config for typescript plugin here
       # see: https://www.graphql-code-generator.com/plugins/typescript
       strictScalars: true
+      # Overrides built-in ID scalar to both input and output types as string.
+      # see: https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars
+      scalars:
+        ID: string
       # You can also write the config for this plugin together
       schema: yup # or zod
 ```

--- a/codegen.yml
+++ b/codegen.yml
@@ -4,6 +4,9 @@ generates:
   example/types.ts:
     plugins:
       - typescript
+    config:
+      scalars:
+        ID: string
   example/yup/schemas.ts:
     plugins:
       - ./dist/main/index.js:
@@ -38,6 +41,8 @@ generates:
               max: ['max', '$1 + 1']
               exclusiveMin: min
               exclusiveMax: max
+          scalars:
+            ID: string
   example/zod/schemas.ts:
     plugins:
       - ./dist/main/index.js:
@@ -59,6 +64,8 @@ generates:
               startsWith: ['regex', '/^$1/', 'message']
               format:
                 email: email
+          scalars:
+            ID: string
   example/myzod/schemas.ts:
     plugins:
       - ./dist/main/index.js:
@@ -72,3 +79,5 @@ generates:
               startsWith: ['pattern', '/^$1/']
               format:
                 email: email
+          scalars:
+            ID: string

--- a/example/types.ts
+++ b/example/types.ts
@@ -3,25 +3,27 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  Date: any;
-  URL: any;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  Date: { input: any; output: any; }
+  URL: { input: any; output: any; }
 };
 
 export type Admin = {
   __typename?: 'Admin';
-  lastModifiedAt?: Maybe<Scalars['Date']>;
+  lastModifiedAt?: Maybe<Scalars['Date']['output']>;
 };
 
 export type AttributeInput = {
-  key?: InputMaybe<Scalars['String']>;
-  val?: InputMaybe<Scalars['String']>;
+  key?: InputMaybe<Scalars['String']['input']>;
+  val?: InputMaybe<Scalars['String']['input']>;
 };
 
 export enum ButtonComponentType {
@@ -33,7 +35,7 @@ export type ComponentInput = {
   child?: InputMaybe<ComponentInput>;
   childrens?: InputMaybe<Array<InputMaybe<ComponentInput>>>;
   event?: InputMaybe<EventInput>;
-  name: Scalars['String'];
+  name: Scalars['String']['input'];
   type: ButtonComponentType;
 };
 
@@ -43,8 +45,8 @@ export type DropDownComponentInput = {
 };
 
 export type EventArgumentInput = {
-  name: Scalars['String'];
-  value: Scalars['String'];
+  name: Scalars['String']['input'];
+  value: Scalars['String']['input'];
 };
 
 export type EventInput = {
@@ -59,12 +61,12 @@ export enum EventOptionType {
 
 export type Guest = {
   __typename?: 'Guest';
-  lastLoggedIn?: Maybe<Scalars['Date']>;
+  lastLoggedIn?: Maybe<Scalars['Date']['output']>;
 };
 
 export type HttpInput = {
   method?: InputMaybe<HttpMethod>;
-  url: Scalars['URL'];
+  url: Scalars['URL']['input'];
 };
 
 export enum HttpMethod {
@@ -78,16 +80,16 @@ export type LayoutInput = {
 
 export type PageInput = {
   attributes?: InputMaybe<Array<AttributeInput>>;
-  date?: InputMaybe<Scalars['Date']>;
-  height: Scalars['Float'];
-  id: Scalars['ID'];
+  date?: InputMaybe<Scalars['Date']['input']>;
+  height: Scalars['Float']['input'];
+  id: Scalars['ID']['input'];
   layout: LayoutInput;
   pageType: PageType;
-  postIDs?: InputMaybe<Array<Scalars['ID']>>;
-  show: Scalars['Boolean'];
-  tags?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  title: Scalars['String'];
-  width: Scalars['Int'];
+  postIDs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  show: Scalars['Boolean']['input'];
+  tags?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title: Scalars['String']['input'];
+  width: Scalars['Int']['input'];
 };
 
 export enum PageType {
@@ -99,13 +101,13 @@ export enum PageType {
 
 export type User = {
   __typename?: 'User';
-  createdAt?: Maybe<Scalars['Date']>;
-  email?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
+  createdAt?: Maybe<Scalars['Date']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
   kind?: Maybe<UserKind>;
-  name?: Maybe<Scalars['String']>;
-  password?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['Date']>;
+  name?: Maybe<Scalars['String']['output']>;
+  password?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['Date']['output']>;
 };
 
 export type UserKind = Admin | Guest;

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,0 +1,36 @@
+import { ValidationSchemaPluginConfig } from './config';
+import { TsVisitor } from '@graphql-codegen/typescript';
+import { NameNode, GraphQLSchema } from 'graphql';
+
+export class Visitor extends TsVisitor {
+  constructor(
+    private scalarDirection: 'input' | 'output' | 'both',
+    private schema: GraphQLSchema,
+    config: ValidationSchemaPluginConfig
+  ) {
+    super(schema, config);
+  }
+
+  public getType(name: string) {
+    return this.schema.getType(name);
+  }
+
+  public getNameNodeConverter(node: NameNode) {
+    const typ = this.schema.getType(node.value);
+    const astNode = typ?.astNode;
+    if (astNode === undefined || astNode === null) {
+      return undefined;
+    }
+    return {
+      targetKind: astNode.kind,
+      convertName: () => this.convertName(astNode.name.value),
+    };
+  }
+
+  public getScalarType(scalarName: string): string | null {
+    if (this.scalarDirection === 'both') {
+      return null;
+    }
+    return this.scalars[scalarName][this.scalarDirection];
+  }
+}

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -5,146 +5,171 @@ describe('myzod', () => {
   test.each([
     [
       'non-null and defined',
-      /* GraphQL */ `
-        input PrimitiveInput {
-          a: ID!
-          b: String!
-          c: Boolean!
-          d: Int!
-          e: Float!
-        }
-      `,
-      [
-        'export function PrimitiveInputSchema(): myzod.Type<PrimitiveInput> {',
-        'a: myzod.string()',
-        'b: myzod.string()',
-        'c: myzod.boolean()',
-        'd: myzod.number()',
-        'e: myzod.number()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input PrimitiveInput {
+            a: ID!
+            b: String!
+            c: Boolean!
+            d: Int!
+            e: Float!
+          }
+        `,
+        wantContains: [
+          'export function PrimitiveInputSchema(): myzod.Type<PrimitiveInput> {',
+          'a: myzod.string()',
+          'b: myzod.string()',
+          'c: myzod.boolean()',
+          'd: myzod.number()',
+          'e: myzod.number()',
+        ],
+        scalars: {
+          ID: 'string',
+        },
+      },
     ],
     [
       'nullish',
-      /* GraphQL */ `
-        input PrimitiveInput {
-          a: ID
-          b: String
-          c: Boolean
-          d: Int
-          e: Float
-          z: String! # no defined check
-        }
-      `,
-      [
-        'export function PrimitiveInputSchema(): myzod.Type<PrimitiveInput> {',
-        // alphabet order
-        'a: myzod.string().optional().nullable(),',
-        'b: myzod.string().optional().nullable(),',
-        'c: myzod.boolean().optional().nullable(),',
-        'd: myzod.number().optional().nullable(),',
-        'e: myzod.number().optional().nullable(),',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input PrimitiveInput {
+            a: ID
+            b: String
+            c: Boolean
+            d: Int
+            e: Float
+            z: String! # no defined check
+          }
+        `,
+        wantContains: [
+          'export function PrimitiveInputSchema(): myzod.Type<PrimitiveInput> {',
+          // alphabet order
+          'a: myzod.string().optional().nullable(),',
+          'b: myzod.string().optional().nullable(),',
+          'c: myzod.boolean().optional().nullable(),',
+          'd: myzod.number().optional().nullable(),',
+          'e: myzod.number().optional().nullable(),',
+        ],
+        scalars: {
+          ID: 'string',
+        },
+      },
     ],
     [
       'array',
-      /* GraphQL */ `
-        input ArrayInput {
-          a: [String]
-          b: [String!]
-          c: [String!]!
-          d: [[String]]
-          e: [[String]!]
-          f: [[String]!]!
-        }
-      `,
-      [
-        'export function ArrayInputSchema(): myzod.Type<ArrayInput> {',
-        'a: myzod.array(myzod.string().nullable()).optional().nullable(),',
-        'b: myzod.array(myzod.string()).optional().nullable(),',
-        'c: myzod.array(myzod.string()),',
-        'd: myzod.array(myzod.array(myzod.string().nullable()).optional().nullable()).optional().nullable(),',
-        'e: myzod.array(myzod.array(myzod.string().nullable())).optional().nullable(),',
-        'f: myzod.array(myzod.array(myzod.string().nullable()))',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input ArrayInput {
+            a: [String]
+            b: [String!]
+            c: [String!]!
+            d: [[String]]
+            e: [[String]!]
+            f: [[String]!]!
+          }
+        `,
+        wantContains: [
+          'export function ArrayInputSchema(): myzod.Type<ArrayInput> {',
+          'a: myzod.array(myzod.string().nullable()).optional().nullable(),',
+          'b: myzod.array(myzod.string()).optional().nullable(),',
+          'c: myzod.array(myzod.string()),',
+          'd: myzod.array(myzod.array(myzod.string().nullable()).optional().nullable()).optional().nullable(),',
+          'e: myzod.array(myzod.array(myzod.string().nullable())).optional().nullable(),',
+          'f: myzod.array(myzod.array(myzod.string().nullable()))',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'ref input object',
-      /* GraphQL */ `
-        input AInput {
-          b: BInput!
-        }
-        input BInput {
-          c: CInput!
-        }
-        input CInput {
-          a: AInput!
-        }
-      `,
-      [
-        'export function AInputSchema(): myzod.Type<AInput> {',
-        'b: myzod.lazy(() => BInputSchema())',
-        'export function BInputSchema(): myzod.Type<BInput> {',
-        'c: myzod.lazy(() => CInputSchema())',
-        'export function CInputSchema(): myzod.Type<CInput> {',
-        'a: myzod.lazy(() => AInputSchema())',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input AInput {
+            b: BInput!
+          }
+          input BInput {
+            c: CInput!
+          }
+          input CInput {
+            a: AInput!
+          }
+        `,
+        wantContains: [
+          'export function AInputSchema(): myzod.Type<AInput> {',
+          'b: myzod.lazy(() => BInputSchema())',
+          'export function BInputSchema(): myzod.Type<BInput> {',
+          'c: myzod.lazy(() => CInputSchema())',
+          'export function CInputSchema(): myzod.Type<CInput> {',
+          'a: myzod.lazy(() => AInputSchema())',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'nested input object',
-      /* GraphQL */ `
-        input NestedInput {
-          child: NestedInput
-          childrens: [NestedInput]
-        }
-      `,
-      [
-        'export function NestedInputSchema(): myzod.Type<NestedInput> {',
-        'child: myzod.lazy(() => NestedInputSchema().optional().nullable()),',
-        'childrens: myzod.array(myzod.lazy(() => NestedInputSchema().nullable())).optional().nullable()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input NestedInput {
+            child: NestedInput
+            childrens: [NestedInput]
+          }
+        `,
+        wantContains: [
+          'export function NestedInputSchema(): myzod.Type<NestedInput> {',
+          'child: myzod.lazy(() => NestedInputSchema().optional().nullable()),',
+          'childrens: myzod.array(myzod.lazy(() => NestedInputSchema().nullable())).optional().nullable()',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'enum',
-      /* GraphQL */ `
-        enum PageType {
-          PUBLIC
-          BASIC_AUTH
-        }
-        input PageInput {
-          pageType: PageType!
-        }
-      `,
-      [
-        'export const PageTypeSchema = myzod.enum(PageType)',
-        'export function PageInputSchema(): myzod.Type<PageInput> {',
-        'pageType: PageTypeSchema',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          enum PageType {
+            PUBLIC
+            BASIC_AUTH
+          }
+          input PageInput {
+            pageType: PageType!
+          }
+        `,
+        wantContains: [
+          'export const PageTypeSchema = myzod.enum(PageType)',
+          'export function PageInputSchema(): myzod.Type<PageInput> {',
+          'pageType: PageTypeSchema',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'camelcase',
-      /* GraphQL */ `
-        input HTTPInput {
-          method: HTTPMethod
-          url: URL!
-        }
+      {
+        textSchema: /* GraphQL */ `
+          input HTTPInput {
+            method: HTTPMethod
+            url: URL!
+          }
 
-        enum HTTPMethod {
-          GET
-          POST
-        }
+          enum HTTPMethod {
+            GET
+            POST
+          }
 
-        scalar URL # unknown scalar, should be any (definedNonNullAnySchema)
-      `,
-      [
-        'export function HttpInputSchema(): myzod.Type<HttpInput> {',
-        'export const HttpMethodSchema = myzod.enum(HttpMethod)',
-        'method: HttpMethodSchema',
-        'url: definedNonNullAnySchema',
-      ],
+          scalar URL # unknown scalar, should be any (definedNonNullAnySchema)
+        `,
+        wantContains: [
+          'export function HttpInputSchema(): myzod.Type<HttpInput> {',
+          'export const HttpMethodSchema = myzod.enum(HttpMethod)',
+          'method: HttpMethodSchema',
+          'url: definedNonNullAnySchema',
+        ],
+        scalars: undefined,
+      },
     ],
-  ])('%s', async (_, textSchema, wantContains) => {
+  ])('%s', async (_, { textSchema, wantContains, scalars }) => {
     const schema = buildSchema(textSchema);
-    const result = await plugin(schema, [], { schema: 'myzod' }, {});
+    const result = await plugin(schema, [], { schema: 'myzod', scalars }, {});
     expect(result.prepend).toContain("import * as myzod from 'myzod'");
 
     for (const wantContain of wantContains) {
@@ -232,6 +257,9 @@ describe('myzod', () => {
       {
         schema: 'myzod',
         notAllowEmptyString: true,
+        scalars: {
+          ID: 'string',
+        },
       },
       {}
     );

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -508,6 +508,10 @@ describe('myzod', () => {
           date: Date!
           email: Email!
         }
+        input UsernameUpdateInput {
+          updateInputId: ID!
+          updateName: String!
+        }
         type User {
           id: ID!
           name: String
@@ -539,6 +543,12 @@ describe('myzod', () => {
             Date: 'myzod.date()',
             Email: 'myzod.string().email()',
           },
+          scalars: {
+            ID: {
+              input: 'number',
+              output: 'string',
+            },
+          },
         },
         {}
       );
@@ -548,6 +558,10 @@ describe('myzod', () => {
         'name: myzod.string(),',
         'date: myzod.date(),',
         'email: myzod.string().email()',
+        // Username Update Input
+        'export function UsernameUpdateInputSchema(): myzod.Type<UsernameUpdateInput> {',
+        'updateInputId: myzod.number(),',
+        'updateName: myzod.string()',
         // User
         'export function UserSchema(): myzod.Type<User> {',
         "__typename: myzod.literal('User').optional(),",

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -422,6 +422,10 @@ describe('yup', () => {
           date: Date!
           email: Email!
         }
+        input UsernameUpdateInput {
+          updateInputId: ID!
+          updateName: String!
+        }
         type User {
           id: ID!
           name: String
@@ -454,6 +458,12 @@ describe('yup', () => {
             Date: 'yup.date()',
             Email: 'yup.string().email()',
           },
+          scalars: {
+            ID: {
+              input: 'number',
+              output: 'string',
+            },
+          },
         },
         {}
       );
@@ -463,6 +473,10 @@ describe('yup', () => {
         'name: yup.string().defined().nonNullable(),',
         'date: yup.date().defined().nonNullable(),',
         'email: yup.string().email().defined().nonNullable()',
+        // Username Update Input
+        'export function UsernameUpdateInputSchema(): yup.ObjectSchema<UsernameUpdateInput> {',
+        'updateInputId: yup.number().defined().nonNullable(),',
+        'updateName: yup.string().defined().nonNullable()',
         // User
         'export function UserSchema(): yup.ObjectSchema<User> {',
         "__typename: yup.string<'User'>().optional(),",

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -5,146 +5,171 @@ describe('yup', () => {
   test.each([
     [
       'defined',
-      /* GraphQL */ `
-        input PrimitiveInput {
-          a: ID!
-          b: String!
-          c: Boolean!
-          d: Int!
-          e: Float!
-        }
-      `,
-      [
-        'export function PrimitiveInputSchema(): yup.ObjectSchema<PrimitiveInput>',
-        'a: yup.string().defined()',
-        'b: yup.string().defined()',
-        'c: yup.boolean().defined()',
-        'd: yup.number().defined()',
-        'e: yup.number().defined()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input PrimitiveInput {
+            a: ID!
+            b: String!
+            c: Boolean!
+            d: Int!
+            e: Float!
+          }
+        `,
+        wantContains: [
+          'export function PrimitiveInputSchema(): yup.ObjectSchema<PrimitiveInput>',
+          'a: yup.string().defined()',
+          'b: yup.string().defined()',
+          'c: yup.boolean().defined()',
+          'd: yup.number().defined()',
+          'e: yup.number().defined()',
+        ],
+        scalars: {
+          ID: 'string',
+        },
+      },
     ],
     [
       'optional',
-      /* GraphQL */ `
-        input PrimitiveInput {
-          a: ID
-          b: String
-          c: Boolean
-          d: Int
-          e: Float
-          z: String! # no defined check
-        }
-      `,
-      [
-        'export function PrimitiveInputSchema(): yup.ObjectSchema<PrimitiveInput>',
-        // alphabet order
-        'a: yup.string().defined().nullable().optional(),',
-        'b: yup.string().defined().nullable().optional(),',
-        'c: yup.boolean().defined().nullable().optional(),',
-        'd: yup.number().defined().nullable().optional(),',
-        'e: yup.number().defined().nullable().optional(),',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input PrimitiveInput {
+            a: ID
+            b: String
+            c: Boolean
+            d: Int
+            e: Float
+            z: String! # no defined check
+          }
+        `,
+        wantContains: [
+          'export function PrimitiveInputSchema(): yup.ObjectSchema<PrimitiveInput>',
+          // alphabet order
+          'a: yup.string().defined().nullable().optional(),',
+          'b: yup.string().defined().nullable().optional(),',
+          'c: yup.boolean().defined().nullable().optional(),',
+          'd: yup.number().defined().nullable().optional(),',
+          'e: yup.number().defined().nullable().optional(),',
+        ],
+        scalars: {
+          ID: 'string',
+        },
+      },
     ],
     [
       'array',
-      /* GraphQL */ `
-        input ArrayInput {
-          a: [String]
-          b: [String!]
-          c: [String!]!
-          d: [[String]]
-          e: [[String]!]
-          f: [[String]!]!
-        }
-      `,
-      [
-        'export function ArrayInputSchema(): yup.ObjectSchema<ArrayInput>',
-        'a: yup.array(yup.string().defined().nullable()).defined().nullable().optional(),',
-        'b: yup.array(yup.string().defined().nonNullable()).defined().nullable().optional(),',
-        'c: yup.array(yup.string().defined().nonNullable()).defined(),',
-        'd: yup.array(yup.array(yup.string().defined().nullable()).defined().nullable()).defined().nullable().optional(),',
-        'e: yup.array(yup.array(yup.string().defined().nullable()).defined()).defined().nullable().optional(),',
-        'f: yup.array(yup.array(yup.string().defined().nullable()).defined()).defined()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input ArrayInput {
+            a: [String]
+            b: [String!]
+            c: [String!]!
+            d: [[String]]
+            e: [[String]!]
+            f: [[String]!]!
+          }
+        `,
+        wantContains: [
+          'export function ArrayInputSchema(): yup.ObjectSchema<ArrayInput>',
+          'a: yup.array(yup.string().defined().nullable()).defined().nullable().optional(),',
+          'b: yup.array(yup.string().defined().nonNullable()).defined().nullable().optional(),',
+          'c: yup.array(yup.string().defined().nonNullable()).defined(),',
+          'd: yup.array(yup.array(yup.string().defined().nullable()).defined().nullable()).defined().nullable().optional(),',
+          'e: yup.array(yup.array(yup.string().defined().nullable()).defined()).defined().nullable().optional(),',
+          'f: yup.array(yup.array(yup.string().defined().nullable()).defined()).defined()',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'ref input object',
-      /* GraphQL */ `
-        input AInput {
-          b: BInput!
-        }
-        input BInput {
-          c: CInput!
-        }
-        input CInput {
-          a: AInput!
-        }
-      `,
-      [
-        'export function AInputSchema(): yup.ObjectSchema<AInput>',
-        'b: yup.lazy(() => BInputSchema().nonNullable())',
-        'export function BInputSchema(): yup.ObjectSchema<BInput>',
-        'c: yup.lazy(() => CInputSchema().nonNullable())',
-        'export function CInputSchema(): yup.ObjectSchema<CInput>',
-        'a: yup.lazy(() => AInputSchema().nonNullable())',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input AInput {
+            b: BInput!
+          }
+          input BInput {
+            c: CInput!
+          }
+          input CInput {
+            a: AInput!
+          }
+        `,
+        wantContains: [
+          'export function AInputSchema(): yup.ObjectSchema<AInput>',
+          'b: yup.lazy(() => BInputSchema().nonNullable())',
+          'export function BInputSchema(): yup.ObjectSchema<BInput>',
+          'c: yup.lazy(() => CInputSchema().nonNullable())',
+          'export function CInputSchema(): yup.ObjectSchema<CInput>',
+          'a: yup.lazy(() => AInputSchema().nonNullable())',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'nested input object',
-      /* GraphQL */ `
-        input NestedInput {
-          child: NestedInput
-          childrens: [NestedInput]
-        }
-      `,
-      [
-        'export function NestedInputSchema(): yup.ObjectSchema<NestedInput>',
-        'child: yup.lazy(() => NestedInputSchema()).optional(),',
-        'childrens: yup.array(yup.lazy(() => NestedInputSchema())).defined().nullable().optional()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input NestedInput {
+            child: NestedInput
+            childrens: [NestedInput]
+          }
+        `,
+        wantContains: [
+          'export function NestedInputSchema(): yup.ObjectSchema<NestedInput>',
+          'child: yup.lazy(() => NestedInputSchema()).optional(),',
+          'childrens: yup.array(yup.lazy(() => NestedInputSchema())).defined().nullable().optional()',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'enum',
-      /* GraphQL */ `
-        enum PageType {
-          PUBLIC
-          BASIC_AUTH
-        }
-        input PageInput {
-          pageType: PageType!
-        }
-      `,
-      [
-        'export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.Public, PageType.BasicAuth]).defined();',
-        'export function PageInputSchema(): yup.ObjectSchema<PageInput>',
-        'pageType: PageTypeSchema.nonNullable()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          enum PageType {
+            PUBLIC
+            BASIC_AUTH
+          }
+          input PageInput {
+            pageType: PageType!
+          }
+        `,
+        wantContains: [
+          'export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.Public, PageType.BasicAuth]).defined();',
+          'export function PageInputSchema(): yup.ObjectSchema<PageInput>',
+          'pageType: PageTypeSchema.nonNullable()',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'camelcase',
-      /* GraphQL */ `
-        input HTTPInput {
-          method: HTTPMethod
-          url: URL!
-        }
+      {
+        textSchema: /* GraphQL */ `
+          input HTTPInput {
+            method: HTTPMethod
+            url: URL!
+          }
 
-        enum HTTPMethod {
-          GET
-          POST
-        }
+          enum HTTPMethod {
+            GET
+            POST
+          }
 
-        scalar URL # unknown scalar, should be any (yup.mixed())
-      `,
-      [
-        'export function HttpInputSchema(): yup.ObjectSchema<HttpInput>',
-        'export const HttpMethodSchema = yup.string<HttpMethod>().oneOf([HttpMethod.Get, HttpMethod.Post]).defined();',
-        'method: HttpMethodSchema.nullable().optional(),',
-        'url: yup.mixed().nonNullable()',
-      ],
+          scalar URL # unknown scalar, should be any (yup.mixed())
+        `,
+        wantContains: [
+          'export function HttpInputSchema(): yup.ObjectSchema<HttpInput>',
+          'export const HttpMethodSchema = yup.string<HttpMethod>().oneOf([HttpMethod.Get, HttpMethod.Post]).defined();',
+          'method: HttpMethodSchema.nullable().optional(),',
+          'url: yup.mixed().nonNullable()',
+        ],
+        scalars: undefined,
+      },
     ],
-  ])('%s', async (_, textSchema, wantContains) => {
+  ])('%s', async (_, { textSchema, wantContains, scalars }) => {
     const schema = buildSchema(textSchema);
-    const result = await plugin(schema, [], {}, {});
+    const result = await plugin(schema, [], { scalars }, {});
     expect(result.prepend).toContain("import * as yup from 'yup'");
 
     for (const wantContain of wantContains) {
@@ -230,6 +255,9 @@ describe('yup', () => {
       [],
       {
         notAllowEmptyString: true,
+        scalars: {
+          ID: 'string',
+        },
       },
       {}
     );

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -511,39 +511,6 @@ describe('zod', () => {
   });
 
   describe('with withObjectType', () => {
-    const schema = buildSchema(/* GraphQL */ `
-      input ScalarsInput {
-        date: Date!
-        email: Email
-      }
-      scalar Date
-      scalar Email
-      input UserCreateInput {
-        name: String!
-        email: Email!
-      }
-      type User {
-        id: ID!
-        name: String
-        age: Int
-        email: Email
-        isMember: Boolean
-        createdAt: Date!
-      }
-
-      type Mutation {
-        _empty: String
-      }
-
-      type Query {
-        _empty: String
-      }
-
-      type Subscription {
-        _empty: String
-      }
-    `);
-
     it('not generate if withObjectType false', async () => {
       const schema = buildSchema(/* GraphQL */ `
         type User {
@@ -612,6 +579,10 @@ describe('zod', () => {
           date: Date!
           email: Email!
         }
+        input UsernameUpdateInput {
+          updateInputId: ID!
+          updateName: String!
+        }
         type User {
           id: ID!
           name: String
@@ -643,6 +614,12 @@ describe('zod', () => {
             Date: 'z.date()',
             Email: 'z.string().email()',
           },
+          scalars: {
+            ID: {
+              input: 'number',
+              output: 'string',
+            },
+          },
         },
         {}
       );
@@ -652,6 +629,10 @@ describe('zod', () => {
         'name: z.string(),',
         'date: z.date(),',
         'email: z.string().email()',
+        // Username Update Input
+        'export function UsernameUpdateInputSchema(): z.ZodObject<Properties<UsernameUpdateInput>> {',
+        'updateInputId: z.number(),',
+        'updateName: z.string()',
         // User
         'export function UserSchema(): z.ZodObject<Properties<User>> {',
         "__typename: z.literal('User').optional()",

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -1,150 +1,176 @@
 import { buildSchema } from 'graphql';
 import { plugin } from '../src/index';
+import { ScalarsMap } from '@graphql-codegen/visitor-plugin-common';
 
 describe('zod', () => {
   test.each([
     [
       'non-null and defined',
-      /* GraphQL */ `
-        input PrimitiveInput {
-          a: ID!
-          b: String!
-          c: Boolean!
-          d: Int!
-          e: Float!
-        }
-      `,
-      [
-        'export function PrimitiveInputSchema(): z.ZodObject<Properties<PrimitiveInput>>',
-        'a: z.string()',
-        'b: z.string()',
-        'c: z.boolean()',
-        'd: z.number()',
-        'e: z.number()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input PrimitiveInput {
+            a: ID!
+            b: String!
+            c: Boolean!
+            d: Int!
+            e: Float!
+          }
+        `,
+        wantContains: [
+          'export function PrimitiveInputSchema(): z.ZodObject<Properties<PrimitiveInput>>',
+          'a: z.string()',
+          'b: z.string()',
+          'c: z.boolean()',
+          'd: z.number()',
+          'e: z.number()',
+        ],
+        scalars: {
+          ID: 'string',
+        },
+      },
     ],
     [
       'nullish',
-      /* GraphQL */ `
-        input PrimitiveInput {
-          a: ID
-          b: String
-          c: Boolean
-          d: Int
-          e: Float
-          z: String! # no defined check
-        }
-      `,
-      [
-        'export function PrimitiveInputSchema(): z.ZodObject<Properties<PrimitiveInput>>',
-        // alphabet order
-        'a: z.string().nullish(),',
-        'b: z.string().nullish(),',
-        'c: z.boolean().nullish(),',
-        'd: z.number().nullish(),',
-        'e: z.number().nullish(),',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input PrimitiveInput {
+            a: ID
+            b: String
+            c: Boolean
+            d: Int
+            e: Float
+            z: String! # no defined check
+          }
+        `,
+        wantContains: [
+          'export function PrimitiveInputSchema(): z.ZodObject<Properties<PrimitiveInput>>',
+          // alphabet order
+          'a: z.string().nullish(),',
+          'b: z.string().nullish(),',
+          'c: z.boolean().nullish(),',
+          'd: z.number().nullish(),',
+          'e: z.number().nullish(),',
+        ],
+        scalars: {
+          ID: 'string',
+        },
+      },
     ],
     [
       'array',
-      /* GraphQL */ `
-        input ArrayInput {
-          a: [String]
-          b: [String!]
-          c: [String!]!
-          d: [[String]]
-          e: [[String]!]
-          f: [[String]!]!
-        }
-      `,
-      [
-        'export function ArrayInputSchema(): z.ZodObject<Properties<ArrayInput>>',
-        'a: z.array(z.string().nullable()).nullish(),',
-        'b: z.array(z.string()).nullish(),',
-        'c: z.array(z.string()),',
-        'd: z.array(z.array(z.string().nullable()).nullish()).nullish(),',
-        'e: z.array(z.array(z.string().nullable())).nullish(),',
-        'f: z.array(z.array(z.string().nullable()))',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input ArrayInput {
+            a: [String]
+            b: [String!]
+            c: [String!]!
+            d: [[String]]
+            e: [[String]!]
+            f: [[String]!]!
+          }
+        `,
+        wantContains: [
+          'export function ArrayInputSchema(): z.ZodObject<Properties<ArrayInput>>',
+          'a: z.array(z.string().nullable()).nullish(),',
+          'b: z.array(z.string()).nullish(),',
+          'c: z.array(z.string()),',
+          'd: z.array(z.array(z.string().nullable()).nullish()).nullish(),',
+          'e: z.array(z.array(z.string().nullable())).nullish(),',
+          'f: z.array(z.array(z.string().nullable()))',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'ref input object',
-      /* GraphQL */ `
-        input AInput {
-          b: BInput!
-        }
-        input BInput {
-          c: CInput!
-        }
-        input CInput {
-          a: AInput!
-        }
-      `,
-      [
-        'export function AInputSchema(): z.ZodObject<Properties<AInput>>',
-        'b: z.lazy(() => BInputSchema())',
-        'export function BInputSchema(): z.ZodObject<Properties<BInput>>',
-        'c: z.lazy(() => CInputSchema())',
-        'export function CInputSchema(): z.ZodObject<Properties<CInput>>',
-        'a: z.lazy(() => AInputSchema())',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input AInput {
+            b: BInput!
+          }
+          input BInput {
+            c: CInput!
+          }
+          input CInput {
+            a: AInput!
+          }
+        `,
+        wantContains: [
+          'export function AInputSchema(): z.ZodObject<Properties<AInput>>',
+          'b: z.lazy(() => BInputSchema())',
+          'export function BInputSchema(): z.ZodObject<Properties<BInput>>',
+          'c: z.lazy(() => CInputSchema())',
+          'export function CInputSchema(): z.ZodObject<Properties<CInput>>',
+          'a: z.lazy(() => AInputSchema())',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'nested input object',
-      /* GraphQL */ `
-        input NestedInput {
-          child: NestedInput
-          childrens: [NestedInput]
-        }
-      `,
-      [
-        'export function NestedInputSchema(): z.ZodObject<Properties<NestedInput>>',
-        'child: z.lazy(() => NestedInputSchema().nullish()),',
-        'childrens: z.array(z.lazy(() => NestedInputSchema().nullable())).nullish()',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          input NestedInput {
+            child: NestedInput
+            childrens: [NestedInput]
+          }
+        `,
+        wantContains: [
+          'export function NestedInputSchema(): z.ZodObject<Properties<NestedInput>>',
+          'child: z.lazy(() => NestedInputSchema().nullish()),',
+          'childrens: z.array(z.lazy(() => NestedInputSchema().nullable())).nullish()',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'enum',
-      /* GraphQL */ `
-        enum PageType {
-          PUBLIC
-          BASIC_AUTH
-        }
-        input PageInput {
-          pageType: PageType!
-        }
-      `,
-      [
-        'export const PageTypeSchema = z.nativeEnum(PageType)',
-        'export function PageInputSchema(): z.ZodObject<Properties<PageInput>>',
-        'pageType: PageTypeSchema',
-      ],
+      {
+        textSchema: /* GraphQL */ `
+          enum PageType {
+            PUBLIC
+            BASIC_AUTH
+          }
+          input PageInput {
+            pageType: PageType!
+          }
+        `,
+        wantContains: [
+          'export const PageTypeSchema = z.nativeEnum(PageType)',
+          'export function PageInputSchema(): z.ZodObject<Properties<PageInput>>',
+          'pageType: PageTypeSchema',
+        ],
+        scalars: undefined,
+      },
     ],
     [
       'camelcase',
-      /* GraphQL */ `
-        input HTTPInput {
-          method: HTTPMethod
-          url: URL!
-        }
+      {
+        textSchema: /* GraphQL */ `
+          input HTTPInput {
+            method: HTTPMethod
+            url: URL!
+          }
 
-        enum HTTPMethod {
-          GET
-          POST
-        }
+          enum HTTPMethod {
+            GET
+            POST
+          }
 
-        scalar URL # unknown scalar, should be any (definedNonNullAnySchema)
-      `,
-      [
-        'export function HttpInputSchema(): z.ZodObject<Properties<HttpInput>>',
-        'export const HttpMethodSchema = z.nativeEnum(HttpMethod)',
-        'method: HttpMethodSchema',
-        'url: definedNonNullAnySchema',
-      ],
+          scalar URL # unknown scalar, should be any (definedNonNullAnySchema)
+        `,
+        wantContains: [
+          'export function HttpInputSchema(): z.ZodObject<Properties<HttpInput>>',
+          'export const HttpMethodSchema = z.nativeEnum(HttpMethod)',
+          'method: HttpMethodSchema',
+          'url: definedNonNullAnySchema',
+        ],
+        scalars: undefined,
+      },
     ],
-  ])('%s', async (_, textSchema, wantContains) => {
+  ])('%s', async (_, { textSchema, wantContains, scalars }) => {
     const schema = buildSchema(textSchema);
-    const result = await plugin(schema, [], { schema: 'zod' }, {});
+    const result = await plugin(schema, [], { schema: 'zod', scalars }, {});
     expect(result.prepend).toContain("import { z } from 'zod'");
 
     for (const wantContain of wantContains) {
@@ -232,6 +258,9 @@ describe('zod', () => {
       {
         schema: 'zod',
         notAllowEmptyString: true,
+        scalars: {
+          ID: 'string',
+        },
       },
       {}
     );


### PR DESCRIPTION
fixed #373 

For those who have been using this plugin, the following adjustments will be required with this PR.

# Before

```yml
    config:
      # You can put the config for typescript plugin here
      # see: https://www.graphql-code-generator.com/plugins/typescript
      strictScalars: true
      # You can also write the config for this plugin together
      schema: yup # or zod
```

## After

```yml
    config:
      # You can put the config for typescript plugin here
      # see: https://www.graphql-code-generator.com/plugins/typescript
      strictScalars: true
      # Overrides built-in ID scalar to both input and output types as string.
      # see: https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars
      scalars:
        ID: string
      # You can also write the config for this plugin together
      schema: yup # or zod
```

By doing this, the built-in type ID will use the string type for both input and output, just as it did before.

In this plugin, if a union such as `string | number` is specified in the scalar, it will generate a validation schema equivalent to validating any type.