### PR TITLE
feat: add `validationSchemaExportType `to config

### DIFF
--- a/example/myzod/schemas.ts
+++ b/example/myzod/schemas.ts
@@ -3,108 +3,84 @@ import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownCom
 
 export const definedNonNullAnySchema = myzod.object({});
 
-export function AdminSchema(): myzod.Type<Admin> {
-  return myzod.object({
-    __typename: myzod.literal('Admin').optional(),
-    lastModifiedAt: definedNonNullAnySchema.optional().nullable()
-  })
-}
-
-export function AttributeInputSchema(): myzod.Type<AttributeInput> {
-  return myzod.object({
-    key: myzod.string().optional().nullable(),
-    val: myzod.string().optional().nullable()
-  })
-}
-
 export const ButtonComponentTypeSchema = myzod.enum(ButtonComponentType);
-
-export function ComponentInputSchema(): myzod.Type<ComponentInput> {
-  return myzod.object({
-    child: myzod.lazy(() => ComponentInputSchema().optional().nullable()),
-    childrens: myzod.array(myzod.lazy(() => ComponentInputSchema().nullable())).optional().nullable(),
-    event: myzod.lazy(() => EventInputSchema().optional().nullable()),
-    name: myzod.string(),
-    type: ButtonComponentTypeSchema
-  })
-}
-
-export function DropDownComponentInputSchema(): myzod.Type<DropDownComponentInput> {
-  return myzod.object({
-    dropdownComponent: myzod.lazy(() => ComponentInputSchema().optional().nullable()),
-    getEvent: myzod.lazy(() => EventInputSchema())
-  })
-}
-
-export function EventArgumentInputSchema(): myzod.Type<EventArgumentInput> {
-  return myzod.object({
-    name: myzod.string().min(5),
-    value: myzod.string().pattern(/^foo/)
-  })
-}
-
-export function EventInputSchema(): myzod.Type<EventInput> {
-  return myzod.object({
-    arguments: myzod.array(myzod.lazy(() => EventArgumentInputSchema())),
-    options: myzod.array(EventOptionTypeSchema).optional().nullable()
-  })
-}
 
 export const EventOptionTypeSchema = myzod.enum(EventOptionType);
 
-export function GuestSchema(): myzod.Type<Guest> {
-  return myzod.object({
-    __typename: myzod.literal('Guest').optional(),
-    lastLoggedIn: definedNonNullAnySchema.optional().nullable()
-  })
-}
-
-export function HttpInputSchema(): myzod.Type<HttpInput> {
-  return myzod.object({
-    method: HttpMethodSchema.optional().nullable(),
-    url: definedNonNullAnySchema
-  })
-}
-
 export const HttpMethodSchema = myzod.enum(HttpMethod);
 
-export function LayoutInputSchema(): myzod.Type<LayoutInput> {
-  return myzod.object({
-    dropdown: myzod.lazy(() => DropDownComponentInputSchema().optional().nullable())
-  })
-}
+export const PageTypeSchema = myzod.enum(PageType);
 
-export function PageInputSchema(): myzod.Type<PageInput> {
-  return myzod.object({
-    attributes: myzod.array(myzod.lazy(() => AttributeInputSchema())).optional().nullable(),
+export const AdminSchema: myzod.Type<Admin> = myzod.object({
+    __typename: myzod.literal('Admin').optional(),
+    lastModifiedAt: definedNonNullAnySchema.optional().nullable()
+});
+
+export const AttributeInputSchema: myzod.Type<AttributeInput> = myzod.object({
+    key: myzod.string().optional().nullable(),
+    val: myzod.string().optional().nullable()
+});
+
+export const ComponentInputSchema: myzod.Type<ComponentInput> = myzod.object({
+    child: myzod.lazy(() => ComponentInputSchema.optional().nullable()),
+    childrens: myzod.array(myzod.lazy(() => ComponentInputSchema.nullable())).optional().nullable(),
+    event: myzod.lazy(() => EventInputSchema.optional().nullable()),
+    name: myzod.string(),
+    type: ButtonComponentTypeSchema
+});
+
+export const DropDownComponentInputSchema: myzod.Type<DropDownComponentInput> = myzod.object({
+    dropdownComponent: myzod.lazy(() => ComponentInputSchema.optional().nullable()),
+    getEvent: myzod.lazy(() => EventInputSchema)
+});
+
+export const EventArgumentInputSchema: myzod.Type<EventArgumentInput> = myzod.object({
+    name: myzod.string().min(5),
+    value: myzod.string().pattern(/^foo/)
+});
+
+export const EventInputSchema: myzod.Type<EventInput> = myzod.object({
+    arguments: myzod.array(myzod.lazy(() => EventArgumentInputSchema)),
+    options: myzod.array(EventOptionTypeSchema).optional().nullable()
+});
+
+export const GuestSchema: myzod.Type<Guest> = myzod.object({
+    __typename: myzod.literal('Guest').optional(),
+    lastLoggedIn: definedNonNullAnySchema.optional().nullable()
+});
+
+export const HttpInputSchema: myzod.Type<HttpInput> = myzod.object({
+    method: HttpMethodSchema.optional().nullable(),
+    url: definedNonNullAnySchema
+});
+
+export const LayoutInputSchema: myzod.Type<LayoutInput> = myzod.object({
+    dropdown: myzod.lazy(() => DropDownComponentInputSchema.optional().nullable())
+});
+
+export const PageInputSchema: myzod.Type<PageInput> = myzod.object({
+    attributes: myzod.array(myzod.lazy(() => AttributeInputSchema)).optional().nullable(),
     date: definedNonNullAnySchema.optional().nullable(),
     height: myzod.number(),
     id: myzod.string(),
-    layout: myzod.lazy(() => LayoutInputSchema()),
+    layout: myzod.lazy(() => LayoutInputSchema),
     pageType: PageTypeSchema,
     postIDs: myzod.array(myzod.string()).optional().nullable(),
     show: myzod.boolean(),
     tags: myzod.array(myzod.string().nullable()).optional().nullable(),
     title: myzod.string(),
     width: myzod.number()
-  })
-}
+});
 
-export const PageTypeSchema = myzod.enum(PageType);
-
-export function UserSchema(): myzod.Type<User> {
-  return myzod.object({
+export const UserSchema: myzod.Type<User> = myzod.object({
     __typename: myzod.literal('User').optional(),
     createdAt: definedNonNullAnySchema.optional().nullable(),
     email: myzod.string().optional().nullable(),
     id: myzod.string().optional().nullable(),
-    kind: UserKindSchema().optional().nullable(),
+    kind: UserKindSchema.optional().nullable(),
     name: myzod.string().optional().nullable(),
     password: myzod.string().optional().nullable(),
     updatedAt: definedNonNullAnySchema.optional().nullable()
-  })
-}
+});
 
-export function UserKindSchema() {
-  return myzod.union([AdminSchema(), GuestSchema()])
-}
+export const UserKindSchema = myzod.union([AdminSchema, GuestSchema]);

--- a/example/yup/schemas.ts
+++ b/example/yup/schemas.ts
@@ -1,114 +1,90 @@
 import * as yup from 'yup'
 import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, Guest, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User, UserKind } from '../types'
 
+export const ButtonComponentTypeSchema = yup.string<ButtonComponentType>().oneOf([ButtonComponentType.Button, ButtonComponentType.Submit]).defined();
+
+export const EventOptionTypeSchema = yup.string<EventOptionType>().oneOf([EventOptionType.Reload, EventOptionType.Retry]).defined();
+
+export const HttpMethodSchema = yup.string<HttpMethod>().oneOf([HttpMethod.Get, HttpMethod.Post]).defined();
+
+export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.BasicAuth, PageType.Lp, PageType.Restricted, PageType.Service]).defined();
+
 function union<T extends {}>(...schemas: ReadonlyArray<yup.Schema<T>>): yup.MixedSchema<T> {
   return yup.mixed<T>().test({
     test: (value) => schemas.some((schema) => schema.isValidSync(value))
   }).defined()
 }
 
-export function AdminSchema(): yup.ObjectSchema<Admin> {
-  return yup.object({
+export const AdminSchema: yup.ObjectSchema<Admin> = yup.object({
     __typename: yup.string<'Admin'>().optional(),
     lastModifiedAt: yup.mixed().nullable().optional()
-  })
-}
+});
 
-export function AttributeInputSchema(): yup.ObjectSchema<AttributeInput> {
-  return yup.object({
+export const AttributeInputSchema: yup.ObjectSchema<AttributeInput> = yup.object({
     key: yup.string().defined().nullable().optional(),
     val: yup.string().defined().nullable().optional()
-  })
-}
+});
 
-export const ButtonComponentTypeSchema = yup.string<ButtonComponentType>().oneOf([ButtonComponentType.Button, ButtonComponentType.Submit]).defined();
-
-export function ComponentInputSchema(): yup.ObjectSchema<ComponentInput> {
-  return yup.object({
-    child: yup.lazy(() => ComponentInputSchema()).optional(),
-    childrens: yup.array(yup.lazy(() => ComponentInputSchema())).defined().nullable().optional(),
-    event: yup.lazy(() => EventInputSchema()).optional(),
+export const ComponentInputSchema: yup.ObjectSchema<ComponentInput> = yup.object({
+    child: yup.lazy(() => ComponentInputSchema).optional(),
+    childrens: yup.array(yup.lazy(() => ComponentInputSchema)).defined().nullable().optional(),
+    event: yup.lazy(() => EventInputSchema).optional(),
     name: yup.string().defined().nonNullable(),
     type: ButtonComponentTypeSchema.nonNullable()
-  })
-}
+});
 
-export function DropDownComponentInputSchema(): yup.ObjectSchema<DropDownComponentInput> {
-  return yup.object({
-    dropdownComponent: yup.lazy(() => ComponentInputSchema()).optional(),
-    getEvent: yup.lazy(() => EventInputSchema().nonNullable())
-  })
-}
+export const DropDownComponentInputSchema: yup.ObjectSchema<DropDownComponentInput> = yup.object({
+    dropdownComponent: yup.lazy(() => ComponentInputSchema).optional(),
+    getEvent: yup.lazy(() => EventInputSchema.nonNullable())
+});
 
-export function EventArgumentInputSchema(): yup.ObjectSchema<EventArgumentInput> {
-  return yup.object({
+export const EventArgumentInputSchema: yup.ObjectSchema<EventArgumentInput> = yup.object({
     name: yup.string().defined().nonNullable().min(5),
     value: yup.string().defined().nonNullable().matches(/^foo/)
-  })
-}
+});
 
-export function EventInputSchema(): yup.ObjectSchema<EventInput> {
-  return yup.object({
-    arguments: yup.array(yup.lazy(() => EventArgumentInputSchema().nonNullable())).defined(),
+export const EventInputSchema: yup.ObjectSchema<EventInput> = yup.object({
+    arguments: yup.array(yup.lazy(() => EventArgumentInputSchema.nonNullable())).defined(),
     options: yup.array(EventOptionTypeSchema.nonNullable()).defined().nullable().optional()
-  })
-}
+});
 
-export const EventOptionTypeSchema = yup.string<EventOptionType>().oneOf([EventOptionType.Reload, EventOptionType.Retry]).defined();
-
-export function GuestSchema(): yup.ObjectSchema<Guest> {
-  return yup.object({
+export const GuestSchema: yup.ObjectSchema<Guest> = yup.object({
     __typename: yup.string<'Guest'>().optional(),
     lastLoggedIn: yup.mixed().nullable().optional()
-  })
-}
+});
 
-export function HttpInputSchema(): yup.ObjectSchema<HttpInput> {
-  return yup.object({
+export const HttpInputSchema: yup.ObjectSchema<HttpInput> = yup.object({
     method: HttpMethodSchema.nullable().optional(),
     url: yup.mixed().nonNullable()
-  })
-}
+});
 
-export const HttpMethodSchema = yup.string<HttpMethod>().oneOf([HttpMethod.Get, HttpMethod.Post]).defined();
+export const LayoutInputSchema: yup.ObjectSchema<LayoutInput> = yup.object({
+    dropdown: yup.lazy(() => DropDownComponentInputSchema).optional()
+});
 
-export function LayoutInputSchema(): yup.ObjectSchema<LayoutInput> {
-  return yup.object({
-    dropdown: yup.lazy(() => DropDownComponentInputSchema()).optional()
-  })
-}
-
-export function PageInputSchema(): yup.ObjectSchema<PageInput> {
-  return yup.object({
-    attributes: yup.array(yup.lazy(() => AttributeInputSchema().nonNullable())).defined().nullable().optional(),
+export const PageInputSchema: yup.ObjectSchema<PageInput> = yup.object({
+    attributes: yup.array(yup.lazy(() => AttributeInputSchema.nonNullable())).defined().nullable().optional(),
     date: yup.mixed().nullable().optional(),
     height: yup.number().defined().nonNullable(),
     id: yup.string().defined().nonNullable(),
-    layout: yup.lazy(() => LayoutInputSchema().nonNullable()),
+    layout: yup.lazy(() => LayoutInputSchema.nonNullable()),
     pageType: PageTypeSchema.nonNullable(),
     postIDs: yup.array(yup.string().defined().nonNullable()).defined().nullable().optional(),
     show: yup.boolean().defined().nonNullable(),
     tags: yup.array(yup.string().defined().nullable()).defined().nullable().optional(),
     title: yup.string().defined().nonNullable(),
     width: yup.number().defined().nonNullable()
-  })
-}
+});
 
-export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.BasicAuth, PageType.Lp, PageType.Restricted, PageType.Service]).defined();
-
-export function UserSchema(): yup.ObjectSchema<User> {
-  return yup.object({
+export const UserSchema: yup.ObjectSchema<User> = yup.object({
     __typename: yup.string<'User'>().optional(),
     createdAt: yup.mixed().nullable().optional(),
     email: yup.string().defined().nullable().optional(),
     id: yup.string().defined().nullable().optional(),
-    kind: UserKindSchema().nullable().optional(),
+    kind: UserKindSchema.nullable().optional(),
     name: yup.string().defined().nullable().optional(),
     password: yup.string().defined().nullable().optional(),
     updatedAt: yup.mixed().nullable().optional()
-  })
-}
+});
 
-export function UserKindSchema(): yup.MixedSchema<UserKind> {
-  return union<UserKind>(AdminSchema(), GuestSchema())
-}
+export const UserKindSchema: yup.MixedSchema<UserKind> = union<UserKind>(AdminSchema, GuestSchema);

--- a/example/zod/schemas.ts
+++ b/example/zod/schemas.ts
@@ -11,108 +11,84 @@ export const isDefinedNonNullAny = (v: any): v is definedNonNullAny => v !== und
 
 export const definedNonNullAnySchema = z.any().refine((v) => isDefinedNonNullAny(v));
 
-export function AdminSchema(): z.ZodObject<Properties<Admin>> {
-  return z.object<Properties<Admin>>({
-    __typename: z.literal('Admin').optional(),
-    lastModifiedAt: definedNonNullAnySchema.nullish()
-  })
-}
-
-export function AttributeInputSchema(): z.ZodObject<Properties<AttributeInput>> {
-  return z.object<Properties<AttributeInput>>({
-    key: z.string().nullish(),
-    val: z.string().nullish()
-  })
-}
-
 export const ButtonComponentTypeSchema = z.nativeEnum(ButtonComponentType);
-
-export function ComponentInputSchema(): z.ZodObject<Properties<ComponentInput>> {
-  return z.object<Properties<ComponentInput>>({
-    child: z.lazy(() => ComponentInputSchema().nullish()),
-    childrens: z.array(z.lazy(() => ComponentInputSchema().nullable())).nullish(),
-    event: z.lazy(() => EventInputSchema().nullish()),
-    name: z.string(),
-    type: ButtonComponentTypeSchema
-  })
-}
-
-export function DropDownComponentInputSchema(): z.ZodObject<Properties<DropDownComponentInput>> {
-  return z.object<Properties<DropDownComponentInput>>({
-    dropdownComponent: z.lazy(() => ComponentInputSchema().nullish()),
-    getEvent: z.lazy(() => EventInputSchema())
-  })
-}
-
-export function EventArgumentInputSchema(): z.ZodObject<Properties<EventArgumentInput>> {
-  return z.object<Properties<EventArgumentInput>>({
-    name: z.string().min(5),
-    value: z.string().regex(/^foo/, "message")
-  })
-}
-
-export function EventInputSchema(): z.ZodObject<Properties<EventInput>> {
-  return z.object<Properties<EventInput>>({
-    arguments: z.array(z.lazy(() => EventArgumentInputSchema())),
-    options: z.array(EventOptionTypeSchema).nullish()
-  })
-}
 
 export const EventOptionTypeSchema = z.nativeEnum(EventOptionType);
 
-export function GuestSchema(): z.ZodObject<Properties<Guest>> {
-  return z.object<Properties<Guest>>({
-    __typename: z.literal('Guest').optional(),
-    lastLoggedIn: definedNonNullAnySchema.nullish()
-  })
-}
-
-export function HttpInputSchema(): z.ZodObject<Properties<HttpInput>> {
-  return z.object<Properties<HttpInput>>({
-    method: HttpMethodSchema.nullish(),
-    url: definedNonNullAnySchema
-  })
-}
-
 export const HttpMethodSchema = z.nativeEnum(HttpMethod);
 
-export function LayoutInputSchema(): z.ZodObject<Properties<LayoutInput>> {
-  return z.object<Properties<LayoutInput>>({
-    dropdown: z.lazy(() => DropDownComponentInputSchema().nullish())
-  })
-}
+export const PageTypeSchema = z.nativeEnum(PageType);
 
-export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
-  return z.object<Properties<PageInput>>({
-    attributes: z.array(z.lazy(() => AttributeInputSchema())).nullish(),
+export const AdminSchema: z.ZodObject<Properties<Admin>> = z.object({
+    __typename: z.literal('Admin').optional(),
+    lastModifiedAt: definedNonNullAnySchema.nullish()
+});
+
+export const AttributeInputSchema: z.ZodObject<Properties<AttributeInput>> = z.object({
+    key: z.string().nullish(),
+    val: z.string().nullish()
+});
+
+export const ComponentInputSchema: z.ZodObject<Properties<ComponentInput>> = z.object({
+    child: z.lazy(() => ComponentInputSchema.nullish()),
+    childrens: z.array(z.lazy(() => ComponentInputSchema.nullable())).nullish(),
+    event: z.lazy(() => EventInputSchema.nullish()),
+    name: z.string(),
+    type: ButtonComponentTypeSchema
+});
+
+export const DropDownComponentInputSchema: z.ZodObject<Properties<DropDownComponentInput>> = z.object({
+    dropdownComponent: z.lazy(() => ComponentInputSchema.nullish()),
+    getEvent: z.lazy(() => EventInputSchema)
+});
+
+export const EventArgumentInputSchema: z.ZodObject<Properties<EventArgumentInput>> = z.object({
+    name: z.string().min(5),
+    value: z.string().regex(/^foo/, "message")
+});
+
+export const EventInputSchema: z.ZodObject<Properties<EventInput>> = z.object({
+    arguments: z.array(z.lazy(() => EventArgumentInputSchema)),
+    options: z.array(EventOptionTypeSchema).nullish()
+});
+
+export const GuestSchema: z.ZodObject<Properties<Guest>> = z.object({
+    __typename: z.literal('Guest').optional(),
+    lastLoggedIn: definedNonNullAnySchema.nullish()
+});
+
+export const HttpInputSchema: z.ZodObject<Properties<HttpInput>> = z.object({
+    method: HttpMethodSchema.nullish(),
+    url: definedNonNullAnySchema
+});
+
+export const LayoutInputSchema: z.ZodObject<Properties<LayoutInput>> = z.object({
+    dropdown: z.lazy(() => DropDownComponentInputSchema.nullish())
+});
+
+export const PageInputSchema: z.ZodObject<Properties<PageInput>> = z.object({
+    attributes: z.array(z.lazy(() => AttributeInputSchema)).nullish(),
     date: definedNonNullAnySchema.nullish(),
     height: z.number(),
     id: z.string(),
-    layout: z.lazy(() => LayoutInputSchema()),
+    layout: z.lazy(() => LayoutInputSchema),
     pageType: PageTypeSchema,
     postIDs: z.array(z.string()).nullish(),
     show: z.boolean(),
     tags: z.array(z.string().nullable()).nullish(),
     title: z.string(),
     width: z.number()
-  })
-}
+});
 
-export const PageTypeSchema = z.nativeEnum(PageType);
-
-export function UserSchema(): z.ZodObject<Properties<User>> {
-  return z.object<Properties<User>>({
+export const UserSchema: z.ZodObject<Properties<User>> = z.object({
     __typename: z.literal('User').optional(),
     createdAt: definedNonNullAnySchema.nullish(),
     email: z.string().nullish(),
     id: z.string().nullish(),
-    kind: UserKindSchema().nullish(),
+    kind: UserKindSchema.nullish(),
     name: z.string().nullish(),
     password: z.string().nullish(),
     updatedAt: definedNonNullAnySchema.nullish()
-  })
-}
+});
 
-export function UserKindSchema() {
-  return z.union([AdminSchema(), GuestSchema()])
-}
+export const UserKindSchema = z.union([AdminSchema, GuestSchema]);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 
 export type ValidationSchema = 'yup' | 'zod' | 'myzod';
+export type ValidationSchemaExportType = 'function' | 'const';
 
 export interface DirectiveConfig {
   [directive: string]: {
@@ -234,4 +235,20 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    * ```
    */
   directives?: DirectiveConfig;
+  /**
+   * @description Specify validation schema export type
+   * @default function
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/file.ts:
+   *     plugins:
+   *       - typescript
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       validationSchemaExportType: const
+   * ```
+   */
+  validationSchemaExportType?: ValidationSchemaExportType;
 }

--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -155,12 +155,11 @@ export const MyZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSche
           .join(', ');
         const unionElementsCount = node.types?.length ?? 0;
 
-        const union =
-          unionElementsCount > 1 ? indent(`return myzod.union([${unionElements}])`) : indent(`return ${unionElements}`);
+        const union = unionElementsCount > 1 ? `myzod.union([${unionElements}])` : unionElements;
 
         switch (config.validationSchemaExportType) {
           case 'const':
-            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withBlock(union)
+            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withContent(union)
               .string;
           case 'function':
           default:
@@ -168,7 +167,7 @@ export const MyZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSche
               .export()
               .asKind('function')
               .withName(`${unionName}Schema()`)
-              .withBlock(union).string;
+              .withBlock(indent(`return ${union}`)).string;
         }
       },
     },

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -187,7 +187,6 @@ export const YupSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
             }
           })
           .join(', ');
-        const union = indent(`return union<${unionName}>(${unionElements})`);
 
         switch (config.validationSchemaExportType) {
           case 'const':
@@ -195,14 +194,14 @@ export const YupSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
               .export()
               .asKind('const')
               .withName(`${unionName}Schema: yup.MixedSchema<${unionName}>`)
-              .withBlock(union).string;
+              .withContent(`union<${unionName}>(${unionElements})`).string;
           case 'function':
           default:
             return new DeclarationBlock({})
               .export()
               .asKind('function')
               .withName(`${unionName}Schema(): yup.MixedSchema<${unionName}>`)
-              .withBlock(union).string;
+              .withBlock(indent(`return union<${unionName}>(${unionElements})`)).string;
         }
       },
     },

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -165,12 +165,11 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
           .join(', ');
         const unionElementsCount = node.types.length ?? 0;
 
-        const union =
-          unionElementsCount > 1 ? indent(`return z.union([${unionElements}])`) : indent(`return ${unionElements}`);
+        const union = unionElementsCount > 1 ? `z.union([${unionElements}])` : unionElements;
 
         switch (config.validationSchemaExportType) {
           case 'const':
-            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withBlock(union)
+            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withContent(union)
               .string;
           case 'function':
           default:
@@ -178,7 +177,7 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
               .export()
               .asKind('function')
               .withName(`${unionName}Schema()`)
-              .withBlock(union).string;
+              .withBlock(indent(`return ${union}`)).string;
         }
       },
     },

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -733,6 +733,43 @@ describe('myzod', () => {
         expect(result.content).toContain(wantContain);
       }
     });
+
+    it('generate union types with single element, export as const', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+
+        type Geometry {
+          shape: Shape
+        }
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withObjectType: true,
+          validationSchemaExportType: 'const',
+        },
+        {}
+      );
+
+      const wantContains = [
+        'export const GeometrySchema: myzod.Type<Geometry> = myzod.object({',
+        "__typename: myzod.literal('Geometry').optional(),",
+        'shape: ShapeSchema.optional().nullable()',
+        '}',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
   });
 
   it('properly generates custom directive values', async () => {

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -647,6 +647,43 @@ describe('yup', () => {
         expect(result.content).toContain(wantContain);
       }
     });
+
+    it('generate union types with single element, export as const', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+
+        type Geometry {
+          shape: Shape
+        }
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'yup',
+          withObjectType: true,
+          validationSchemaExportType: 'const',
+        },
+        {}
+      );
+
+      const wantContains = [
+        'export const GeometrySchema: yup.ObjectSchema<Geometry> = yup.object({',
+        "__typename: yup.string<'Geometry'>().optional(),",
+        'shape: ShapeSchema.nullable().optional()',
+        '})',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
   });
 
   it('properly generates custom directive values', async () => {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -837,4 +837,88 @@ describe('zod', () => {
       expect(result.content).toContain(wantContain);
     }
   });
+
+  it('exports as const instead of func', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input Say {
+        phrase: String!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'zod',
+        validationSchemaExportType: 'const',
+      },
+      {}
+    );
+    expect(result.content).toContain('export const SaySchema: z.ZodObject<Properties<Say>> = z.object({');
+  });
+
+  it('generate both input & type, export as const', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      scalar Date
+      scalar Email
+      input UserCreateInput {
+        name: String!
+        date: Date!
+        email: Email!
+      }
+      type User {
+        id: ID!
+        name: String
+        age: Int
+        email: Email
+        isMember: Boolean
+        createdAt: Date!
+      }
+      type Mutation {
+        _empty: String
+      }
+      type Query {
+        _empty: String
+      }
+      type Subscription {
+        _empty: String
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'zod',
+        withObjectType: true,
+        scalarSchemas: {
+          Date: 'z.date()',
+          Email: 'z.string().email()',
+        },
+        validationSchemaExportType: 'const',
+      },
+      {}
+    );
+    const wantContains = [
+      // User Create Input
+      'export const UserCreateInputSchema: z.ZodObject<Properties<UserCreateInput>> = z.object({',
+      'name: z.string(),',
+      'date: z.date(),',
+      'email: z.string().email()',
+      // User
+      'export const UserSchema: z.ZodObject<Properties<User>> = z.object({',
+      "__typename: z.literal('User').optional()",
+      'id: z.string(),',
+      'name: z.string().nullish(),',
+      'age: z.number().nullish(),',
+      'isMember: z.boolean().nullish(),',
+      'email: z.string().email().nullish(),',
+      'createdAt: z.date()',
+    ];
+    for (const wantContain of wantContains) {
+      expect(result.content).toContain(wantContain);
+    }
+
+    for (const wantNotContain of ['Query', 'Mutation', 'Subscription']) {
+      expect(result.content).not.toContain(wantNotContain);
+    }
+  });
 });

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -1,6 +1,5 @@
 import { buildSchema } from 'graphql';
 import { plugin } from '../src/index';
-import { ScalarsMap } from '@graphql-codegen/visitor-plugin-common';
 
 describe('zod', () => {
   test.each([
@@ -797,6 +796,42 @@ describe('zod', () => {
         'export function AnyTypeSchema() {',
         'return z.union([PageTypeSchema, MethodTypeSchema])',
         '}',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
+
+    it('generate union types with single element, export as const', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+
+        type Geometry {
+          shape: Shape
+        }
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'zod',
+          withObjectType: true,
+          validationSchemaExportType: 'const',
+        },
+        {}
+      );
+
+      const wantContains = [
+        'export const GeometrySchema: z.ZodObject<Properties<Geometry>> = z.object({',
+        "__typename: z.literal('Geometry').optional(),",
+        'shape: ShapeSchema.nullish()',
       ];
       for (const wantContain of wantContains) {
         expect(result.content).toContain(wantContain);


### PR DESCRIPTION
Resolves #164 

Adds a new config option, `validationSchemaExportType`, to specify the export type of the generated validation schema (either `function` or `const`), Feature supports yup, zod, and myzod.