### PR TITLE
feat: add `validationSchemaExportType` to config w/ resolve deps

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -13,6 +13,7 @@ generates:
           schema: yup
           importFrom: ../types
           withObjectType: true
+          validationSchemaExportType: const
           directives:
             required:
               msg: required
@@ -49,6 +50,7 @@ generates:
           schema: zod
           importFrom: ../types
           withObjectType: true
+          validationSchemaExportType: const
           directives:
             # Write directives like
             #
@@ -72,6 +74,7 @@ generates:
           schema: myzod
           importFrom: ../types
           withObjectType: true
+          validationSchemaExportType: const
           directives:
             constraint:
               minLength: min

--- a/example/myzod/schemas.ts
+++ b/example/myzod/schemas.ts
@@ -3,108 +3,84 @@ import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownCom
 
 export const definedNonNullAnySchema = myzod.object({});
 
-export function AdminSchema(): myzod.Type<Admin> {
-  return myzod.object({
-    __typename: myzod.literal('Admin').optional(),
-    lastModifiedAt: definedNonNullAnySchema.optional().nullable()
-  })
-}
-
-export function AttributeInputSchema(): myzod.Type<AttributeInput> {
-  return myzod.object({
-    key: myzod.string().optional().nullable(),
-    val: myzod.string().optional().nullable()
-  })
-}
-
 export const ButtonComponentTypeSchema = myzod.enum(ButtonComponentType);
-
-export function ComponentInputSchema(): myzod.Type<ComponentInput> {
-  return myzod.object({
-    child: myzod.lazy(() => ComponentInputSchema().optional().nullable()),
-    childrens: myzod.array(myzod.lazy(() => ComponentInputSchema().nullable())).optional().nullable(),
-    event: myzod.lazy(() => EventInputSchema().optional().nullable()),
-    name: myzod.string(),
-    type: ButtonComponentTypeSchema
-  })
-}
-
-export function DropDownComponentInputSchema(): myzod.Type<DropDownComponentInput> {
-  return myzod.object({
-    dropdownComponent: myzod.lazy(() => ComponentInputSchema().optional().nullable()),
-    getEvent: myzod.lazy(() => EventInputSchema())
-  })
-}
-
-export function EventArgumentInputSchema(): myzod.Type<EventArgumentInput> {
-  return myzod.object({
-    name: myzod.string().min(5),
-    value: myzod.string().pattern(/^foo/)
-  })
-}
-
-export function EventInputSchema(): myzod.Type<EventInput> {
-  return myzod.object({
-    arguments: myzod.array(myzod.lazy(() => EventArgumentInputSchema())),
-    options: myzod.array(EventOptionTypeSchema).optional().nullable()
-  })
-}
 
 export const EventOptionTypeSchema = myzod.enum(EventOptionType);
 
-export function GuestSchema(): myzod.Type<Guest> {
-  return myzod.object({
-    __typename: myzod.literal('Guest').optional(),
-    lastLoggedIn: definedNonNullAnySchema.optional().nullable()
-  })
-}
-
-export function HttpInputSchema(): myzod.Type<HttpInput> {
-  return myzod.object({
-    method: HttpMethodSchema.optional().nullable(),
-    url: definedNonNullAnySchema
-  })
-}
-
 export const HttpMethodSchema = myzod.enum(HttpMethod);
 
-export function LayoutInputSchema(): myzod.Type<LayoutInput> {
-  return myzod.object({
-    dropdown: myzod.lazy(() => DropDownComponentInputSchema().optional().nullable())
-  })
-}
+export const PageTypeSchema = myzod.enum(PageType);
 
-export function PageInputSchema(): myzod.Type<PageInput> {
-  return myzod.object({
-    attributes: myzod.array(myzod.lazy(() => AttributeInputSchema())).optional().nullable(),
+export const AdminSchema: myzod.Type<Admin> = myzod.object({
+    __typename: myzod.literal('Admin').optional(),
+    lastModifiedAt: definedNonNullAnySchema.optional().nullable()
+});
+
+export const AttributeInputSchema: myzod.Type<AttributeInput> = myzod.object({
+    key: myzod.string().optional().nullable(),
+    val: myzod.string().optional().nullable()
+});
+
+export const ComponentInputSchema: myzod.Type<ComponentInput> = myzod.object({
+    child: myzod.lazy(() => ComponentInputSchema.optional().nullable()),
+    childrens: myzod.array(myzod.lazy(() => ComponentInputSchema.nullable())).optional().nullable(),
+    event: myzod.lazy(() => EventInputSchema.optional().nullable()),
+    name: myzod.string(),
+    type: ButtonComponentTypeSchema
+});
+
+export const DropDownComponentInputSchema: myzod.Type<DropDownComponentInput> = myzod.object({
+    dropdownComponent: myzod.lazy(() => ComponentInputSchema.optional().nullable()),
+    getEvent: myzod.lazy(() => EventInputSchema)
+});
+
+export const EventArgumentInputSchema: myzod.Type<EventArgumentInput> = myzod.object({
+    name: myzod.string().min(5),
+    value: myzod.string().pattern(/^foo/)
+});
+
+export const EventInputSchema: myzod.Type<EventInput> = myzod.object({
+    arguments: myzod.array(myzod.lazy(() => EventArgumentInputSchema)),
+    options: myzod.array(EventOptionTypeSchema).optional().nullable()
+});
+
+export const GuestSchema: myzod.Type<Guest> = myzod.object({
+    __typename: myzod.literal('Guest').optional(),
+    lastLoggedIn: definedNonNullAnySchema.optional().nullable()
+});
+
+export const HttpInputSchema: myzod.Type<HttpInput> = myzod.object({
+    method: HttpMethodSchema.optional().nullable(),
+    url: definedNonNullAnySchema
+});
+
+export const LayoutInputSchema: myzod.Type<LayoutInput> = myzod.object({
+    dropdown: myzod.lazy(() => DropDownComponentInputSchema.optional().nullable())
+});
+
+export const PageInputSchema: myzod.Type<PageInput> = myzod.object({
+    attributes: myzod.array(myzod.lazy(() => AttributeInputSchema)).optional().nullable(),
     date: definedNonNullAnySchema.optional().nullable(),
     height: myzod.number(),
     id: myzod.string(),
-    layout: myzod.lazy(() => LayoutInputSchema()),
+    layout: myzod.lazy(() => LayoutInputSchema),
     pageType: PageTypeSchema,
     postIDs: myzod.array(myzod.string()).optional().nullable(),
     show: myzod.boolean(),
     tags: myzod.array(myzod.string().nullable()).optional().nullable(),
     title: myzod.string(),
     width: myzod.number()
-  })
-}
+});
 
-export const PageTypeSchema = myzod.enum(PageType);
-
-export function UserSchema(): myzod.Type<User> {
-  return myzod.object({
+export const UserSchema: myzod.Type<User> = myzod.object({
     __typename: myzod.literal('User').optional(),
     createdAt: definedNonNullAnySchema.optional().nullable(),
     email: myzod.string().optional().nullable(),
     id: myzod.string().optional().nullable(),
-    kind: UserKindSchema().optional().nullable(),
+    kind: UserKindSchema.optional().nullable(),
     name: myzod.string().optional().nullable(),
     password: myzod.string().optional().nullable(),
     updatedAt: definedNonNullAnySchema.optional().nullable()
-  })
-}
+});
 
-export function UserKindSchema() {
-  return myzod.union([AdminSchema(), GuestSchema()])
-}
+export const UserKindSchema = myzod.union([AdminSchema, GuestSchema]);

--- a/example/myzod/schemas.ts
+++ b/example/myzod/schemas.ts
@@ -1,24 +1,29 @@
 import * as myzod from 'myzod'
-import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, Guest, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User } from '../types'
+import { PageType, HttpMethod, HttpInput, EventOptionType, EventArgumentInput, EventInput, ComponentInput, DropDownComponentInput, LayoutInput, ButtonComponentType, AttributeInput, PageInput, Guest, Admin, User } from '../types'
 
 export const definedNonNullAnySchema = myzod.object({});
 
-export const ButtonComponentTypeSchema = myzod.enum(ButtonComponentType);
-
-export const EventOptionTypeSchema = myzod.enum(EventOptionType);
+export const PageTypeSchema = myzod.enum(PageType);
 
 export const HttpMethodSchema = myzod.enum(HttpMethod);
 
-export const PageTypeSchema = myzod.enum(PageType);
+export const EventOptionTypeSchema = myzod.enum(EventOptionType);
 
-export const AdminSchema: myzod.Type<Admin> = myzod.object({
-    __typename: myzod.literal('Admin').optional(),
-    lastModifiedAt: definedNonNullAnySchema.optional().nullable()
+export const ButtonComponentTypeSchema = myzod.enum(ButtonComponentType);
+
+export const HttpInputSchema: myzod.Type<HttpInput> = myzod.object({
+    method: HttpMethodSchema.optional().nullable(),
+    url: definedNonNullAnySchema
 });
 
-export const AttributeInputSchema: myzod.Type<AttributeInput> = myzod.object({
-    key: myzod.string().optional().nullable(),
-    val: myzod.string().optional().nullable()
+export const EventArgumentInputSchema: myzod.Type<EventArgumentInput> = myzod.object({
+    name: myzod.string().min(5),
+    value: myzod.string().pattern(/^foo/)
+});
+
+export const EventInputSchema: myzod.Type<EventInput> = myzod.object({
+    arguments: myzod.array(myzod.lazy(() => EventArgumentInputSchema)),
+    options: myzod.array(EventOptionTypeSchema).optional().nullable()
 });
 
 export const ComponentInputSchema: myzod.Type<ComponentInput> = myzod.object({
@@ -34,28 +39,13 @@ export const DropDownComponentInputSchema: myzod.Type<DropDownComponentInput> = 
     getEvent: myzod.lazy(() => EventInputSchema)
 });
 
-export const EventArgumentInputSchema: myzod.Type<EventArgumentInput> = myzod.object({
-    name: myzod.string().min(5),
-    value: myzod.string().pattern(/^foo/)
-});
-
-export const EventInputSchema: myzod.Type<EventInput> = myzod.object({
-    arguments: myzod.array(myzod.lazy(() => EventArgumentInputSchema)),
-    options: myzod.array(EventOptionTypeSchema).optional().nullable()
-});
-
-export const GuestSchema: myzod.Type<Guest> = myzod.object({
-    __typename: myzod.literal('Guest').optional(),
-    lastLoggedIn: definedNonNullAnySchema.optional().nullable()
-});
-
-export const HttpInputSchema: myzod.Type<HttpInput> = myzod.object({
-    method: HttpMethodSchema.optional().nullable(),
-    url: definedNonNullAnySchema
-});
-
 export const LayoutInputSchema: myzod.Type<LayoutInput> = myzod.object({
     dropdown: myzod.lazy(() => DropDownComponentInputSchema.optional().nullable())
+});
+
+export const AttributeInputSchema: myzod.Type<AttributeInput> = myzod.object({
+    key: myzod.string().optional().nullable(),
+    val: myzod.string().optional().nullable()
 });
 
 export const PageInputSchema: myzod.Type<PageInput> = myzod.object({
@@ -72,6 +62,18 @@ export const PageInputSchema: myzod.Type<PageInput> = myzod.object({
     width: myzod.number()
 });
 
+export const GuestSchema: myzod.Type<Guest> = myzod.object({
+    __typename: myzod.literal('Guest').optional(),
+    lastLoggedIn: definedNonNullAnySchema.optional().nullable()
+});
+
+export const AdminSchema: myzod.Type<Admin> = myzod.object({
+    __typename: myzod.literal('Admin').optional(),
+    lastModifiedAt: definedNonNullAnySchema.optional().nullable()
+});
+
+export const UserKindSchema = myzod.union([AdminSchema, GuestSchema]);
+
 export const UserSchema: myzod.Type<User> = myzod.object({
     __typename: myzod.literal('User').optional(),
     createdAt: definedNonNullAnySchema.optional().nullable(),
@@ -82,5 +84,3 @@ export const UserSchema: myzod.Type<User> = myzod.object({
     password: myzod.string().optional().nullable(),
     updatedAt: definedNonNullAnySchema.optional().nullable()
 });
-
-export const UserKindSchema = myzod.union([AdminSchema, GuestSchema]);

--- a/example/yup/schemas.ts
+++ b/example/yup/schemas.ts
@@ -1,13 +1,13 @@
 import * as yup from 'yup'
-import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, Guest, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User, UserKind } from '../types'
+import { PageType, HttpMethod, HttpInput, EventOptionType, EventArgumentInput, EventInput, ComponentInput, DropDownComponentInput, LayoutInput, ButtonComponentType, AttributeInput, PageInput, Guest, Admin, UserKind, User } from '../types'
 
-export const ButtonComponentTypeSchema = yup.string<ButtonComponentType>().oneOf([ButtonComponentType.Button, ButtonComponentType.Submit]).defined();
-
-export const EventOptionTypeSchema = yup.string<EventOptionType>().oneOf([EventOptionType.Reload, EventOptionType.Retry]).defined();
+export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.BasicAuth, PageType.Lp, PageType.Restricted, PageType.Service]).defined();
 
 export const HttpMethodSchema = yup.string<HttpMethod>().oneOf([HttpMethod.Get, HttpMethod.Post]).defined();
 
-export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.BasicAuth, PageType.Lp, PageType.Restricted, PageType.Service]).defined();
+export const EventOptionTypeSchema = yup.string<EventOptionType>().oneOf([EventOptionType.Reload, EventOptionType.Retry]).defined();
+
+export const ButtonComponentTypeSchema = yup.string<ButtonComponentType>().oneOf([ButtonComponentType.Button, ButtonComponentType.Submit]).defined();
 
 function union<T extends {}>(...schemas: ReadonlyArray<yup.Schema<T>>): yup.MixedSchema<T> {
   return yup.mixed<T>().test({
@@ -15,14 +15,19 @@ function union<T extends {}>(...schemas: ReadonlyArray<yup.Schema<T>>): yup.Mixe
   }).defined()
 }
 
-export const AdminSchema: yup.ObjectSchema<Admin> = yup.object({
-    __typename: yup.string<'Admin'>().optional(),
-    lastModifiedAt: yup.mixed().nullable().optional()
+export const HttpInputSchema: yup.ObjectSchema<HttpInput> = yup.object({
+    method: HttpMethodSchema.nullable().optional(),
+    url: yup.mixed().nonNullable()
 });
 
-export const AttributeInputSchema: yup.ObjectSchema<AttributeInput> = yup.object({
-    key: yup.string().defined().nullable().optional(),
-    val: yup.string().defined().nullable().optional()
+export const EventArgumentInputSchema: yup.ObjectSchema<EventArgumentInput> = yup.object({
+    name: yup.string().defined().nonNullable().min(5),
+    value: yup.string().defined().nonNullable().matches(/^foo/)
+});
+
+export const EventInputSchema: yup.ObjectSchema<EventInput> = yup.object({
+    arguments: yup.array(yup.lazy(() => EventArgumentInputSchema.nonNullable())).defined(),
+    options: yup.array(EventOptionTypeSchema.nonNullable()).defined().nullable().optional()
 });
 
 export const ComponentInputSchema: yup.ObjectSchema<ComponentInput> = yup.object({
@@ -38,28 +43,13 @@ export const DropDownComponentInputSchema: yup.ObjectSchema<DropDownComponentInp
     getEvent: yup.lazy(() => EventInputSchema.nonNullable())
 });
 
-export const EventArgumentInputSchema: yup.ObjectSchema<EventArgumentInput> = yup.object({
-    name: yup.string().defined().nonNullable().min(5),
-    value: yup.string().defined().nonNullable().matches(/^foo/)
-});
-
-export const EventInputSchema: yup.ObjectSchema<EventInput> = yup.object({
-    arguments: yup.array(yup.lazy(() => EventArgumentInputSchema.nonNullable())).defined(),
-    options: yup.array(EventOptionTypeSchema.nonNullable()).defined().nullable().optional()
-});
-
-export const GuestSchema: yup.ObjectSchema<Guest> = yup.object({
-    __typename: yup.string<'Guest'>().optional(),
-    lastLoggedIn: yup.mixed().nullable().optional()
-});
-
-export const HttpInputSchema: yup.ObjectSchema<HttpInput> = yup.object({
-    method: HttpMethodSchema.nullable().optional(),
-    url: yup.mixed().nonNullable()
-});
-
 export const LayoutInputSchema: yup.ObjectSchema<LayoutInput> = yup.object({
     dropdown: yup.lazy(() => DropDownComponentInputSchema).optional()
+});
+
+export const AttributeInputSchema: yup.ObjectSchema<AttributeInput> = yup.object({
+    key: yup.string().defined().nullable().optional(),
+    val: yup.string().defined().nullable().optional()
 });
 
 export const PageInputSchema: yup.ObjectSchema<PageInput> = yup.object({
@@ -76,6 +66,18 @@ export const PageInputSchema: yup.ObjectSchema<PageInput> = yup.object({
     width: yup.number().defined().nonNullable()
 });
 
+export const GuestSchema: yup.ObjectSchema<Guest> = yup.object({
+    __typename: yup.string<'Guest'>().optional(),
+    lastLoggedIn: yup.mixed().nullable().optional()
+});
+
+export const AdminSchema: yup.ObjectSchema<Admin> = yup.object({
+    __typename: yup.string<'Admin'>().optional(),
+    lastModifiedAt: yup.mixed().nullable().optional()
+});
+
+export const UserKindSchema: yup.MixedSchema<UserKind> = union<UserKind>(AdminSchema, GuestSchema);
+
 export const UserSchema: yup.ObjectSchema<User> = yup.object({
     __typename: yup.string<'User'>().optional(),
     createdAt: yup.mixed().nullable().optional(),
@@ -86,5 +88,3 @@ export const UserSchema: yup.ObjectSchema<User> = yup.object({
     password: yup.string().defined().nullable().optional(),
     updatedAt: yup.mixed().nullable().optional()
 });
-
-export const UserKindSchema: yup.MixedSchema<UserKind> = union<UserKind>(AdminSchema, GuestSchema);

--- a/example/yup/schemas.ts
+++ b/example/yup/schemas.ts
@@ -1,114 +1,90 @@
 import * as yup from 'yup'
 import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, Guest, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User, UserKind } from '../types'
 
+export const ButtonComponentTypeSchema = yup.string<ButtonComponentType>().oneOf([ButtonComponentType.Button, ButtonComponentType.Submit]).defined();
+
+export const EventOptionTypeSchema = yup.string<EventOptionType>().oneOf([EventOptionType.Reload, EventOptionType.Retry]).defined();
+
+export const HttpMethodSchema = yup.string<HttpMethod>().oneOf([HttpMethod.Get, HttpMethod.Post]).defined();
+
+export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.BasicAuth, PageType.Lp, PageType.Restricted, PageType.Service]).defined();
+
 function union<T extends {}>(...schemas: ReadonlyArray<yup.Schema<T>>): yup.MixedSchema<T> {
   return yup.mixed<T>().test({
     test: (value) => schemas.some((schema) => schema.isValidSync(value))
   }).defined()
 }
 
-export function AdminSchema(): yup.ObjectSchema<Admin> {
-  return yup.object({
+export const AdminSchema: yup.ObjectSchema<Admin> = yup.object({
     __typename: yup.string<'Admin'>().optional(),
     lastModifiedAt: yup.mixed().nullable().optional()
-  })
-}
+});
 
-export function AttributeInputSchema(): yup.ObjectSchema<AttributeInput> {
-  return yup.object({
+export const AttributeInputSchema: yup.ObjectSchema<AttributeInput> = yup.object({
     key: yup.string().defined().nullable().optional(),
     val: yup.string().defined().nullable().optional()
-  })
-}
+});
 
-export const ButtonComponentTypeSchema = yup.string<ButtonComponentType>().oneOf([ButtonComponentType.Button, ButtonComponentType.Submit]).defined();
-
-export function ComponentInputSchema(): yup.ObjectSchema<ComponentInput> {
-  return yup.object({
-    child: yup.lazy(() => ComponentInputSchema()).optional(),
-    childrens: yup.array(yup.lazy(() => ComponentInputSchema())).defined().nullable().optional(),
-    event: yup.lazy(() => EventInputSchema()).optional(),
+export const ComponentInputSchema: yup.ObjectSchema<ComponentInput> = yup.object({
+    child: yup.lazy(() => ComponentInputSchema).optional(),
+    childrens: yup.array(yup.lazy(() => ComponentInputSchema)).defined().nullable().optional(),
+    event: yup.lazy(() => EventInputSchema).optional(),
     name: yup.string().defined().nonNullable(),
     type: ButtonComponentTypeSchema.nonNullable()
-  })
-}
+});
 
-export function DropDownComponentInputSchema(): yup.ObjectSchema<DropDownComponentInput> {
-  return yup.object({
-    dropdownComponent: yup.lazy(() => ComponentInputSchema()).optional(),
-    getEvent: yup.lazy(() => EventInputSchema().nonNullable())
-  })
-}
+export const DropDownComponentInputSchema: yup.ObjectSchema<DropDownComponentInput> = yup.object({
+    dropdownComponent: yup.lazy(() => ComponentInputSchema).optional(),
+    getEvent: yup.lazy(() => EventInputSchema.nonNullable())
+});
 
-export function EventArgumentInputSchema(): yup.ObjectSchema<EventArgumentInput> {
-  return yup.object({
+export const EventArgumentInputSchema: yup.ObjectSchema<EventArgumentInput> = yup.object({
     name: yup.string().defined().nonNullable().min(5),
     value: yup.string().defined().nonNullable().matches(/^foo/)
-  })
-}
+});
 
-export function EventInputSchema(): yup.ObjectSchema<EventInput> {
-  return yup.object({
-    arguments: yup.array(yup.lazy(() => EventArgumentInputSchema().nonNullable())).defined(),
+export const EventInputSchema: yup.ObjectSchema<EventInput> = yup.object({
+    arguments: yup.array(yup.lazy(() => EventArgumentInputSchema.nonNullable())).defined(),
     options: yup.array(EventOptionTypeSchema.nonNullable()).defined().nullable().optional()
-  })
-}
+});
 
-export const EventOptionTypeSchema = yup.string<EventOptionType>().oneOf([EventOptionType.Reload, EventOptionType.Retry]).defined();
-
-export function GuestSchema(): yup.ObjectSchema<Guest> {
-  return yup.object({
+export const GuestSchema: yup.ObjectSchema<Guest> = yup.object({
     __typename: yup.string<'Guest'>().optional(),
     lastLoggedIn: yup.mixed().nullable().optional()
-  })
-}
+});
 
-export function HttpInputSchema(): yup.ObjectSchema<HttpInput> {
-  return yup.object({
+export const HttpInputSchema: yup.ObjectSchema<HttpInput> = yup.object({
     method: HttpMethodSchema.nullable().optional(),
     url: yup.mixed().nonNullable()
-  })
-}
+});
 
-export const HttpMethodSchema = yup.string<HttpMethod>().oneOf([HttpMethod.Get, HttpMethod.Post]).defined();
+export const LayoutInputSchema: yup.ObjectSchema<LayoutInput> = yup.object({
+    dropdown: yup.lazy(() => DropDownComponentInputSchema).optional()
+});
 
-export function LayoutInputSchema(): yup.ObjectSchema<LayoutInput> {
-  return yup.object({
-    dropdown: yup.lazy(() => DropDownComponentInputSchema()).optional()
-  })
-}
-
-export function PageInputSchema(): yup.ObjectSchema<PageInput> {
-  return yup.object({
-    attributes: yup.array(yup.lazy(() => AttributeInputSchema().nonNullable())).defined().nullable().optional(),
+export const PageInputSchema: yup.ObjectSchema<PageInput> = yup.object({
+    attributes: yup.array(yup.lazy(() => AttributeInputSchema.nonNullable())).defined().nullable().optional(),
     date: yup.mixed().nullable().optional(),
     height: yup.number().defined().nonNullable(),
     id: yup.string().defined().nonNullable(),
-    layout: yup.lazy(() => LayoutInputSchema().nonNullable()),
+    layout: yup.lazy(() => LayoutInputSchema.nonNullable()),
     pageType: PageTypeSchema.nonNullable(),
     postIDs: yup.array(yup.string().defined().nonNullable()).defined().nullable().optional(),
     show: yup.boolean().defined().nonNullable(),
     tags: yup.array(yup.string().defined().nullable()).defined().nullable().optional(),
     title: yup.string().defined().nonNullable(),
     width: yup.number().defined().nonNullable()
-  })
-}
+});
 
-export const PageTypeSchema = yup.string<PageType>().oneOf([PageType.BasicAuth, PageType.Lp, PageType.Restricted, PageType.Service]).defined();
-
-export function UserSchema(): yup.ObjectSchema<User> {
-  return yup.object({
+export const UserSchema: yup.ObjectSchema<User> = yup.object({
     __typename: yup.string<'User'>().optional(),
     createdAt: yup.mixed().nullable().optional(),
     email: yup.string().defined().nullable().optional(),
     id: yup.string().defined().nullable().optional(),
-    kind: UserKindSchema().nullable().optional(),
+    kind: UserKindSchema.nullable().optional(),
     name: yup.string().defined().nullable().optional(),
     password: yup.string().defined().nullable().optional(),
     updatedAt: yup.mixed().nullable().optional()
-  })
-}
+});
 
-export function UserKindSchema(): yup.MixedSchema<UserKind> {
-  return union<UserKind>(AdminSchema(), GuestSchema())
-}
+export const UserKindSchema: yup.MixedSchema<UserKind> = union<UserKind>(AdminSchema, GuestSchema);

--- a/example/zod/schemas.ts
+++ b/example/zod/schemas.ts
@@ -11,108 +11,84 @@ export const isDefinedNonNullAny = (v: any): v is definedNonNullAny => v !== und
 
 export const definedNonNullAnySchema = z.any().refine((v) => isDefinedNonNullAny(v));
 
-export function AdminSchema(): z.ZodObject<Properties<Admin>> {
-  return z.object<Properties<Admin>>({
-    __typename: z.literal('Admin').optional(),
-    lastModifiedAt: definedNonNullAnySchema.nullish()
-  })
-}
-
-export function AttributeInputSchema(): z.ZodObject<Properties<AttributeInput>> {
-  return z.object<Properties<AttributeInput>>({
-    key: z.string().nullish(),
-    val: z.string().nullish()
-  })
-}
-
 export const ButtonComponentTypeSchema = z.nativeEnum(ButtonComponentType);
-
-export function ComponentInputSchema(): z.ZodObject<Properties<ComponentInput>> {
-  return z.object<Properties<ComponentInput>>({
-    child: z.lazy(() => ComponentInputSchema().nullish()),
-    childrens: z.array(z.lazy(() => ComponentInputSchema().nullable())).nullish(),
-    event: z.lazy(() => EventInputSchema().nullish()),
-    name: z.string(),
-    type: ButtonComponentTypeSchema
-  })
-}
-
-export function DropDownComponentInputSchema(): z.ZodObject<Properties<DropDownComponentInput>> {
-  return z.object<Properties<DropDownComponentInput>>({
-    dropdownComponent: z.lazy(() => ComponentInputSchema().nullish()),
-    getEvent: z.lazy(() => EventInputSchema())
-  })
-}
-
-export function EventArgumentInputSchema(): z.ZodObject<Properties<EventArgumentInput>> {
-  return z.object<Properties<EventArgumentInput>>({
-    name: z.string().min(5),
-    value: z.string().regex(/^foo/, "message")
-  })
-}
-
-export function EventInputSchema(): z.ZodObject<Properties<EventInput>> {
-  return z.object<Properties<EventInput>>({
-    arguments: z.array(z.lazy(() => EventArgumentInputSchema())),
-    options: z.array(EventOptionTypeSchema).nullish()
-  })
-}
 
 export const EventOptionTypeSchema = z.nativeEnum(EventOptionType);
 
-export function GuestSchema(): z.ZodObject<Properties<Guest>> {
-  return z.object<Properties<Guest>>({
-    __typename: z.literal('Guest').optional(),
-    lastLoggedIn: definedNonNullAnySchema.nullish()
-  })
-}
-
-export function HttpInputSchema(): z.ZodObject<Properties<HttpInput>> {
-  return z.object<Properties<HttpInput>>({
-    method: HttpMethodSchema.nullish(),
-    url: definedNonNullAnySchema
-  })
-}
-
 export const HttpMethodSchema = z.nativeEnum(HttpMethod);
 
-export function LayoutInputSchema(): z.ZodObject<Properties<LayoutInput>> {
-  return z.object<Properties<LayoutInput>>({
-    dropdown: z.lazy(() => DropDownComponentInputSchema().nullish())
-  })
-}
+export const PageTypeSchema = z.nativeEnum(PageType);
 
-export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
-  return z.object<Properties<PageInput>>({
-    attributes: z.array(z.lazy(() => AttributeInputSchema())).nullish(),
+export const AdminSchema: z.ZodObject<Properties<Admin>> = z.object({
+    __typename: z.literal('Admin').optional(),
+    lastModifiedAt: definedNonNullAnySchema.nullish()
+});
+
+export const AttributeInputSchema: z.ZodObject<Properties<AttributeInput>> = z.object({
+    key: z.string().nullish(),
+    val: z.string().nullish()
+});
+
+export const ComponentInputSchema: z.ZodObject<Properties<ComponentInput>> = z.object({
+    child: z.lazy(() => ComponentInputSchema.nullish()),
+    childrens: z.array(z.lazy(() => ComponentInputSchema.nullable())).nullish(),
+    event: z.lazy(() => EventInputSchema.nullish()),
+    name: z.string(),
+    type: ButtonComponentTypeSchema
+});
+
+export const DropDownComponentInputSchema: z.ZodObject<Properties<DropDownComponentInput>> = z.object({
+    dropdownComponent: z.lazy(() => ComponentInputSchema.nullish()),
+    getEvent: z.lazy(() => EventInputSchema)
+});
+
+export const EventArgumentInputSchema: z.ZodObject<Properties<EventArgumentInput>> = z.object({
+    name: z.string().min(5),
+    value: z.string().regex(/^foo/, "message")
+});
+
+export const EventInputSchema: z.ZodObject<Properties<EventInput>> = z.object({
+    arguments: z.array(z.lazy(() => EventArgumentInputSchema)),
+    options: z.array(EventOptionTypeSchema).nullish()
+});
+
+export const GuestSchema: z.ZodObject<Properties<Guest>> = z.object({
+    __typename: z.literal('Guest').optional(),
+    lastLoggedIn: definedNonNullAnySchema.nullish()
+});
+
+export const HttpInputSchema: z.ZodObject<Properties<HttpInput>> = z.object({
+    method: HttpMethodSchema.nullish(),
+    url: definedNonNullAnySchema
+});
+
+export const LayoutInputSchema: z.ZodObject<Properties<LayoutInput>> = z.object({
+    dropdown: z.lazy(() => DropDownComponentInputSchema.nullish())
+});
+
+export const PageInputSchema: z.ZodObject<Properties<PageInput>> = z.object({
+    attributes: z.array(z.lazy(() => AttributeInputSchema)).nullish(),
     date: definedNonNullAnySchema.nullish(),
     height: z.number(),
     id: z.string(),
-    layout: z.lazy(() => LayoutInputSchema()),
+    layout: z.lazy(() => LayoutInputSchema),
     pageType: PageTypeSchema,
     postIDs: z.array(z.string()).nullish(),
     show: z.boolean(),
     tags: z.array(z.string().nullable()).nullish(),
     title: z.string(),
     width: z.number()
-  })
-}
+});
 
-export const PageTypeSchema = z.nativeEnum(PageType);
-
-export function UserSchema(): z.ZodObject<Properties<User>> {
-  return z.object<Properties<User>>({
+export const UserSchema: z.ZodObject<Properties<User>> = z.object({
     __typename: z.literal('User').optional(),
     createdAt: definedNonNullAnySchema.nullish(),
     email: z.string().nullish(),
     id: z.string().nullish(),
-    kind: UserKindSchema().nullish(),
+    kind: UserKindSchema.nullish(),
     name: z.string().nullish(),
     password: z.string().nullish(),
     updatedAt: definedNonNullAnySchema.nullish()
-  })
-}
+});
 
-export function UserKindSchema() {
-  return z.union([AdminSchema(), GuestSchema()])
-}
+export const UserKindSchema = z.union([AdminSchema, GuestSchema]);

--- a/example/zod/schemas.ts
+++ b/example/zod/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, Guest, HttpInput, HttpMethod, LayoutInput, PageInput, PageType, User } from '../types'
+import { PageType, HttpMethod, HttpInput, EventOptionType, EventArgumentInput, EventInput, ComponentInput, DropDownComponentInput, LayoutInput, ButtonComponentType, AttributeInput, PageInput, Guest, Admin, User } from '../types'
 
 type Properties<T> = Required<{
   [K in keyof T]: z.ZodType<T[K], any, T[K]>;
@@ -11,22 +11,27 @@ export const isDefinedNonNullAny = (v: any): v is definedNonNullAny => v !== und
 
 export const definedNonNullAnySchema = z.any().refine((v) => isDefinedNonNullAny(v));
 
-export const ButtonComponentTypeSchema = z.nativeEnum(ButtonComponentType);
-
-export const EventOptionTypeSchema = z.nativeEnum(EventOptionType);
+export const PageTypeSchema = z.nativeEnum(PageType);
 
 export const HttpMethodSchema = z.nativeEnum(HttpMethod);
 
-export const PageTypeSchema = z.nativeEnum(PageType);
+export const EventOptionTypeSchema = z.nativeEnum(EventOptionType);
 
-export const AdminSchema: z.ZodObject<Properties<Admin>> = z.object({
-    __typename: z.literal('Admin').optional(),
-    lastModifiedAt: definedNonNullAnySchema.nullish()
+export const ButtonComponentTypeSchema = z.nativeEnum(ButtonComponentType);
+
+export const HttpInputSchema: z.ZodObject<Properties<HttpInput>> = z.object({
+    method: HttpMethodSchema.nullish(),
+    url: definedNonNullAnySchema
 });
 
-export const AttributeInputSchema: z.ZodObject<Properties<AttributeInput>> = z.object({
-    key: z.string().nullish(),
-    val: z.string().nullish()
+export const EventArgumentInputSchema: z.ZodObject<Properties<EventArgumentInput>> = z.object({
+    name: z.string().min(5),
+    value: z.string().regex(/^foo/, "message")
+});
+
+export const EventInputSchema: z.ZodObject<Properties<EventInput>> = z.object({
+    arguments: z.array(z.lazy(() => EventArgumentInputSchema)),
+    options: z.array(EventOptionTypeSchema).nullish()
 });
 
 export const ComponentInputSchema: z.ZodObject<Properties<ComponentInput>> = z.object({
@@ -42,28 +47,13 @@ export const DropDownComponentInputSchema: z.ZodObject<Properties<DropDownCompon
     getEvent: z.lazy(() => EventInputSchema)
 });
 
-export const EventArgumentInputSchema: z.ZodObject<Properties<EventArgumentInput>> = z.object({
-    name: z.string().min(5),
-    value: z.string().regex(/^foo/, "message")
-});
-
-export const EventInputSchema: z.ZodObject<Properties<EventInput>> = z.object({
-    arguments: z.array(z.lazy(() => EventArgumentInputSchema)),
-    options: z.array(EventOptionTypeSchema).nullish()
-});
-
-export const GuestSchema: z.ZodObject<Properties<Guest>> = z.object({
-    __typename: z.literal('Guest').optional(),
-    lastLoggedIn: definedNonNullAnySchema.nullish()
-});
-
-export const HttpInputSchema: z.ZodObject<Properties<HttpInput>> = z.object({
-    method: HttpMethodSchema.nullish(),
-    url: definedNonNullAnySchema
-});
-
 export const LayoutInputSchema: z.ZodObject<Properties<LayoutInput>> = z.object({
     dropdown: z.lazy(() => DropDownComponentInputSchema.nullish())
+});
+
+export const AttributeInputSchema: z.ZodObject<Properties<AttributeInput>> = z.object({
+    key: z.string().nullish(),
+    val: z.string().nullish()
 });
 
 export const PageInputSchema: z.ZodObject<Properties<PageInput>> = z.object({
@@ -80,6 +70,18 @@ export const PageInputSchema: z.ZodObject<Properties<PageInput>> = z.object({
     width: z.number()
 });
 
+export const GuestSchema: z.ZodObject<Properties<Guest>> = z.object({
+    __typename: z.literal('Guest').optional(),
+    lastLoggedIn: definedNonNullAnySchema.nullish()
+});
+
+export const AdminSchema: z.ZodObject<Properties<Admin>> = z.object({
+    __typename: z.literal('Admin').optional(),
+    lastModifiedAt: definedNonNullAnySchema.nullish()
+});
+
+export const UserKindSchema = z.union([AdminSchema, GuestSchema]);
+
 export const UserSchema: z.ZodObject<Properties<User>> = z.object({
     __typename: z.literal('User').optional(),
     createdAt: definedNonNullAnySchema.nullish(),
@@ -90,5 +92,3 @@ export const UserSchema: z.ZodObject<Properties<User>> = z.object({
     password: z.string().nullish(),
     updatedAt: definedNonNullAnySchema.nullish()
 });
-
-export const UserKindSchema = z.union([AdminSchema, GuestSchema]);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@graphql-codegen/cli": "4.0.1",
     "@graphql-codegen/typescript": "^4.0.0",
     "@tsconfig/recommended": "1.0.2",
+    "@types/graphlib": "^2.1.8",
     "@types/jest": "29.5.2",
     "@types/node": "^20.1.3",
     "@typescript-eslint/eslint-plugin": "5.59.8",
@@ -59,6 +60,7 @@
     "myzod": "1.10.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.8.8",
+    "ts-dedent": "^2.2.0",
     "ts-jest": "29.1.0",
     "typescript": "5.1.3",
     "yup": "1.2.0",
@@ -69,6 +71,7 @@
     "@graphql-codegen/schema-ast": "4.0.0",
     "@graphql-codegen/visitor-plugin-common": "^4.0.0",
     "@graphql-tools/utils": "^10.0.0",
+    "graphlib": "^2.1.8",
     "graphql": "^16.6.0"
   },
   "peerDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 
 export type ValidationSchema = 'yup' | 'zod' | 'myzod';
+export type ValidationSchemaExportType = 'function' | 'const';
 
 export interface DirectiveConfig {
   [directive: string]: {
@@ -234,4 +235,20 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    * ```
    */
   directives?: DirectiveConfig;
+  /**
+   * @description Specify validation schema export type
+   * @default function
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/file.ts:
+   *     plugins:
+   *       - typescript
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       validationSchemaExportType: const
+   * ```
+   */
+  validationSchemaExportType?: ValidationSchemaExportType;
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,4 +1,17 @@
-import { ListTypeNode, NonNullTypeNode, NamedTypeNode, TypeNode, ObjectTypeDefinitionNode } from 'graphql';
+import {
+  ListTypeNode,
+  NonNullTypeNode,
+  NamedTypeNode,
+  TypeNode,
+  ObjectTypeDefinitionNode,
+  visit,
+  DocumentNode,
+  DefinitionNode,
+  NameNode,
+  ASTNode,
+  GraphQLSchema,
+} from 'graphql';
+import { Graph } from 'graphlib';
 
 export const isListType = (typ?: TypeNode): typ is ListTypeNode => typ?.kind === 'ListType';
 export const isNonNullType = (typ?: TypeNode): typ is NonNullTypeNode => typ?.kind === 'NonNullType';
@@ -19,4 +32,135 @@ export const ObjectTypeDefinitionBuilder = (
     }
     return callback(node);
   };
+};
+
+export const topologicalSortAST = (schema: GraphQLSchema, ast: DocumentNode): DocumentNode => {
+  const dependencyGraph = new Graph();
+  const targetKinds = [
+    'ObjectTypeDefinition',
+    'InputObjectTypeDefinition',
+    'EnumTypeDefinition',
+    'UnionTypeDefinition',
+    'ScalarTypeDefinition',
+  ];
+
+  visit<DocumentNode>(ast, {
+    enter: node => {
+      switch (node.kind) {
+        case 'ObjectTypeDefinition':
+        case 'InputObjectTypeDefinition': {
+          const typeName = node.name.value;
+          dependencyGraph.setNode(typeName);
+
+          if (node.fields) {
+            node.fields.forEach(field => {
+              if (field.type.kind === 'NamedType') {
+                const dependency = field.type.name.value;
+                const typ = schema.getType(dependency);
+                if (typ?.astNode?.kind === undefined || !targetKinds.includes(typ.astNode.kind)) {
+                  return;
+                }
+                if (!dependencyGraph.hasNode(dependency)) {
+                  dependencyGraph.setNode(dependency);
+                }
+                dependencyGraph.setEdge(typeName, dependency);
+              }
+            });
+          }
+          break;
+        }
+        case 'ScalarTypeDefinition':
+        case 'EnumTypeDefinition': {
+          dependencyGraph.setNode(node.name.value);
+          break;
+        }
+        case 'UnionTypeDefinition': {
+          const dependency = node.name.value;
+          if (!dependencyGraph.hasNode(dependency)) {
+            dependencyGraph.setNode(dependency);
+          }
+          node.types?.forEach(type => {
+            const dependency = type.name.value;
+            const typ = schema.getType(dependency);
+            if (typ?.astNode?.kind === undefined || !targetKinds.includes(typ.astNode.kind)) {
+              return;
+            }
+            dependencyGraph.setEdge(node.name.value, dependency);
+          });
+          break;
+        }
+        default:
+          break;
+      }
+    },
+  });
+
+  const sorted = topsort(dependencyGraph);
+
+  // Create a map of definitions for quick access, using the definition's name as the key.
+  const definitionsMap: Map<string, DefinitionNode> = new Map();
+  ast.definitions.forEach(definition => {
+    if (hasNameField(definition) && definition.name) {
+      definitionsMap.set(definition.name.value, definition);
+    }
+  });
+
+  // Two arrays to store sorted and not sorted definitions.
+  const sortedDefinitions: DefinitionNode[] = [];
+  const notSortedDefinitions: DefinitionNode[] = [];
+
+  // Iterate over sorted type names and retrieve their corresponding definitions.
+  sorted.forEach(sortedType => {
+    const definition = definitionsMap.get(sortedType);
+    if (definition) {
+      sortedDefinitions.push(definition);
+      definitionsMap.delete(sortedType);
+    }
+  });
+
+  // Definitions that are left in the map were not included in sorted list
+  // Add them to notSortedDefinitions.
+  definitionsMap.forEach(definition => notSortedDefinitions.push(definition));
+
+  const definitions = [...sortedDefinitions, ...notSortedDefinitions];
+
+  if (definitions.length !== ast.definitions.length) {
+    throw new Error(
+      `unexpected definition length after sorted: want ${ast.definitions.length} but got ${definitions.length}`
+    );
+  }
+
+  return {
+    ...ast,
+    definitions: definitions as ReadonlyArray<DefinitionNode>,
+  };
+};
+
+const hasNameField = (node: ASTNode): node is DefinitionNode & { name?: NameNode } => {
+  return 'name' in node;
+};
+
+// Re-implemented w/o CycleException version
+// https://github.com/dagrejs/graphlib/blob/8d27cb89029081c72eb89dde652602805bdd0a34/lib/alg/topsort.js
+export const topsort = (g: Graph): string[] => {
+  const visited: Record<string, boolean> = {};
+  const stack: Record<string, boolean> = {};
+  const results: any[] = [];
+
+  function visit(node: string) {
+    if (!(node in visited)) {
+      stack[node] = true;
+      visited[node] = true;
+      const predecessors = g.predecessors(node);
+      if (Array.isArray(predecessors)) {
+        predecessors.forEach(node => visit(node));
+      }
+      delete stack[node];
+      results.push(node);
+    }
+  }
+
+  g.sinks().forEach(node => visit(node));
+
+  return results.reverse();
 };

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -99,7 +99,12 @@ export const topologicalSortAST = (schema: GraphQLSchema, ast: DocumentNode): Do
 
   // Create a map of definitions for quick access, using the definition's name as the key.
   const definitionsMap: Map<string, DefinitionNode> = new Map();
-  ast.definitions.forEach(definition => {
+
+  // SCHEMA_DEFINITION does not have name.
+  // https://spec.graphql.org/October2021/#sec-Schema
+  const astDefinitions = ast.definitions.filter(def => def.kind !== 'SchemaDefinition');
+
+  astDefinitions.forEach(definition => {
     if (hasNameField(definition) && definition.name) {
       definitionsMap.set(definition.name.value, definition);
     }
@@ -122,17 +127,17 @@ export const topologicalSortAST = (schema: GraphQLSchema, ast: DocumentNode): Do
   // Add them to notSortedDefinitions.
   definitionsMap.forEach(definition => notSortedDefinitions.push(definition));
 
-  const definitions = [...sortedDefinitions, ...notSortedDefinitions];
+  const newDefinitions = [...sortedDefinitions, ...notSortedDefinitions];
 
-  if (definitions.length !== ast.definitions.length) {
+  if (newDefinitions.length !== astDefinitions.length) {
     throw new Error(
-      `unexpected definition length after sorted: want ${ast.definitions.length} but got ${definitions.length}`
+      `unexpected definition length after sorted: want ${astDefinitions.length} but got ${newDefinitions.length}`
     );
   }
 
   return {
     ...ast,
-    definitions: definitions as ReadonlyArray<DefinitionNode>,
+    definitions: newDefinitions as ReadonlyArray<DefinitionNode>,
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ const schemaVisitor = (schema: GraphQLSchema, config: ValidationSchemaPluginConf
 
 const _transformSchemaAST = (schema: GraphQLSchema, config: ValidationSchemaPluginConfig) => {
   const { schema: _schema, ast } = transformSchemaAST(schema, config);
+  // This affects the performance of code generation, so it is
+  // enabled only when this option is selected.
   if (config.validationSchemaExportType === 'const') {
     return {
       schema: _schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,14 @@ import { ValidationSchemaPluginConfig } from './config';
 import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 import { GraphQLSchema, visit } from 'graphql';
 import { SchemaVisitor } from './types';
+import { topologicalSortAST } from './graphql';
 
 export const plugin: PluginFunction<ValidationSchemaPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
   _documents: Types.DocumentFile[],
   config: ValidationSchemaPluginConfig
 ): Types.ComplexPluginOutput => {
-  const { schema: _schema, ast } = transformSchemaAST(schema, config);
+  const { schema: _schema, ast } = _transformSchemaAST(schema, config);
   const { buildImports, initialEmit, ...visitor } = schemaVisitor(_schema, config);
 
   const result = visit(ast, visitor);
@@ -34,4 +35,18 @@ const schemaVisitor = (schema: GraphQLSchema, config: ValidationSchemaPluginConf
     return MyZodSchemaVisitor(schema, config);
   }
   return YupSchemaVisitor(schema, config);
+};
+
+const _transformSchemaAST = (schema: GraphQLSchema, config: ValidationSchemaPluginConfig) => {
+  const { schema: _schema, ast } = transformSchemaAST(schema, config);
+  if (config.validationSchemaExportType === 'const') {
+    return {
+      schema: _schema,
+      ast: topologicalSortAST(_schema, ast),
+    };
+  }
+  return {
+    schema: _schema,
+    ast,
+  };
 };

--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -155,12 +155,11 @@ export const MyZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSche
           .join(', ');
         const unionElementsCount = node.types?.length ?? 0;
 
-        const union =
-          unionElementsCount > 1 ? indent(`return myzod.union([${unionElements}])`) : indent(`return ${unionElements}`);
+        const union = unionElementsCount > 1 ? `myzod.union([${unionElements}])` : unionElements;
 
         switch (config.validationSchemaExportType) {
           case 'const':
-            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withBlock(union)
+            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withContent(union)
               .string;
           case 'function':
           default:
@@ -168,7 +167,7 @@ export const MyZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSche
               .export()
               .asKind('function')
               .withName(`${unionName}Schema()`)
-              .withBlock(union).string;
+              .withBlock(indent(`return ${union}`)).string;
         }
       },
     },

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -187,7 +187,6 @@ export const YupSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
             }
           })
           .join(', ');
-        const union = indent(`return union<${unionName}>(${unionElements})`);
 
         switch (config.validationSchemaExportType) {
           case 'const':
@@ -195,14 +194,14 @@ export const YupSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
               .export()
               .asKind('const')
               .withName(`${unionName}Schema: yup.MixedSchema<${unionName}>`)
-              .withBlock(union).string;
+              .withContent(`union<${unionName}>(${unionElements})`).string;
           case 'function':
           default:
             return new DeclarationBlock({})
               .export()
               .asKind('function')
               .withName(`${unionName}Schema(): yup.MixedSchema<${unionName}>`)
-              .withBlock(union).string;
+              .withBlock(indent(`return union<${unionName}>(${unionElements})`)).string;
         }
       },
     },

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -165,12 +165,11 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
           .join(', ');
         const unionElementsCount = node.types.length ?? 0;
 
-        const union =
-          unionElementsCount > 1 ? indent(`return z.union([${unionElements}])`) : indent(`return ${unionElements}`);
+        const union = unionElementsCount > 1 ? `z.union([${unionElements}])` : unionElements;
 
         switch (config.validationSchemaExportType) {
           case 'const':
-            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withBlock(union)
+            return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withContent(union)
               .string;
           case 'function':
           default:
@@ -178,7 +177,7 @@ export const ZodSchemaVisitor = (schema: GraphQLSchema, config: ValidationSchema
               .export()
               .asKind('function')
               .withName(`${unionName}Schema()`)
-              .withBlock(union).string;
+              .withBlock(indent(`return ${union}`)).string;
         }
       },
     },

--- a/tests/graphql.spec.ts
+++ b/tests/graphql.spec.ts
@@ -1,5 +1,7 @@
-import { Kind, ObjectTypeDefinitionNode } from 'graphql';
-import { ObjectTypeDefinitionBuilder } from '../src/graphql';
+import { Kind, ObjectTypeDefinitionNode, buildSchema, parse, print } from 'graphql';
+import { ObjectTypeDefinitionBuilder, topsort, topologicalSortAST } from '../src/graphql';
+import { Graph } from 'graphlib';
+import dedent from 'ts-dedent';
 
 describe('graphql', () => {
   describe('ObjectTypeDefinitionBuilder', () => {
@@ -42,5 +44,196 @@ describe('graphql', () => {
         expect(objectTypeDefFn).toBeUndefined();
       });
     });
+  });
+});
+
+describe('topsort', () => {
+  it('should correctly sort nodes based on their dependencies', () => {
+    const g = new Graph();
+
+    // Setting up the graph
+    g.setNode('A');
+    g.setNode('B');
+    g.setNode('C');
+    g.setEdge('A', 'B');
+    g.setEdge('B', 'C');
+
+    const sortedNodes = topsort(g);
+    expect(sortedNodes).toEqual(['C', 'B', 'A']);
+  });
+
+  it('should correctly handle graph with no edges', () => {
+    const g = new Graph();
+
+    // Setting up the graph
+    g.setNode('A');
+    g.setNode('B');
+    g.setNode('C');
+
+    const sortedNodes = topsort(g);
+    const isCorrectOrder = ['A', 'B', 'C'].every(node => sortedNodes.includes(node));
+    expect(isCorrectOrder).toBe(true);
+  });
+
+  it('should correctly handle an empty graph', () => {
+    const g = new Graph();
+
+    const sortedNodes = topsort(g);
+    expect(sortedNodes).toEqual([]);
+  });
+
+  it('should correctly handle graph with multiple dependencies', () => {
+    const g = new Graph();
+
+    // Setting up the graph
+    g.setNode('A');
+    g.setNode('B');
+    g.setNode('C');
+    g.setNode('D');
+    g.setEdge('A', 'B');
+    g.setEdge('A', 'C');
+    g.setEdge('B', 'D');
+    g.setEdge('C', 'D');
+
+    const sortedNodes = topsort(g);
+    expect(sortedNodes).toEqual(['D', 'C', 'B', 'A']);
+  });
+});
+
+describe('topologicalSortAST', () => {
+  const getSortedSchema = (schema: string): string => {
+    const ast = parse(schema);
+    const sortedAst = topologicalSortAST(buildSchema(schema), ast);
+    return print(sortedAst);
+  };
+
+  it('should correctly sort nodes based on their input type dependencies', () => {
+    const schema = /* GraphQL */ `
+      input A {
+        b: B
+      }
+
+      input B {
+        c: C
+      }
+
+      input C {
+        d: String
+      }
+    `;
+
+    const sortedSchema = getSortedSchema(schema);
+
+    const expectedSortedSchema = dedent/* GraphQL */ `
+      input C {
+        d: String
+      }
+
+      input B {
+        c: C
+      }
+
+      input A {
+        b: B
+      }
+    `;
+
+    expect(sortedSchema).toBe(expectedSortedSchema);
+  });
+
+  it('should correctly sort nodes based on their objet type dependencies', () => {
+    const schema = /* GraphQL */ `
+      type D {
+        e: UserKind
+      }
+
+      union UserKind = A | B
+
+      type A {
+        b: B
+      }
+
+      type B {
+        c: C
+      }
+
+      type C {
+        d: String
+      }
+    `;
+
+    const sortedSchema = getSortedSchema(schema);
+
+    const expectedSortedSchema = dedent/* GraphQL */ `
+      type C {
+        d: String
+      }
+
+      type B {
+        c: C
+      }
+
+      type A {
+        b: B
+      }
+
+      union UserKind = A | B
+
+      type D {
+        e: UserKind
+      }
+    `;
+
+    expect(sortedSchema).toBe(expectedSortedSchema);
+  });
+
+  it('should correctly handle schema with circular dependencies', () => {
+    const schema = /* GraphQL */ `
+      input A {
+        b: B
+      }
+
+      input B {
+        a: A
+      }
+    `;
+    const sortedSchema = getSortedSchema(schema);
+
+    const expectedSortedSchema = dedent/* GraphQL */ `
+      input A {
+        b: B
+      }
+
+      input B {
+        a: A
+      }
+    `;
+
+    expect(sortedSchema).toBe(expectedSortedSchema);
+  });
+
+  it('should correctly handle schema with self circular dependencies', () => {
+    const schema = /* GraphQL */ `
+      input A {
+        a: A
+      }
+
+      input B {
+        b: B
+      }
+    `;
+    const sortedSchema = getSortedSchema(schema);
+
+    const expectedSortedSchema = dedent/* GraphQL */ `
+      input A {
+        a: A
+      }
+
+      input B {
+        b: B
+      }
+    `;
+
+    expect(sortedSchema).toBe(expectedSortedSchema);
   });
 });

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -733,6 +733,43 @@ describe('myzod', () => {
         expect(result.content).toContain(wantContain);
       }
     });
+
+    it('generate union types with single element, export as const', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+
+        type Geometry {
+          shape: Shape
+        }
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withObjectType: true,
+          validationSchemaExportType: 'const',
+        },
+        {}
+      );
+
+      const wantContains = [
+        'export const GeometrySchema: myzod.Type<Geometry> = myzod.object({',
+        "__typename: myzod.literal('Geometry').optional(),",
+        'shape: ShapeSchema.optional().nullable()',
+        '}',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
   });
 
   it('properly generates custom directive values', async () => {

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -647,6 +647,43 @@ describe('yup', () => {
         expect(result.content).toContain(wantContain);
       }
     });
+
+    it('generate union types with single element, export as const', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+
+        type Geometry {
+          shape: Shape
+        }
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'yup',
+          withObjectType: true,
+          validationSchemaExportType: 'const',
+        },
+        {}
+      );
+
+      const wantContains = [
+        'export const GeometrySchema: yup.ObjectSchema<Geometry> = yup.object({',
+        "__typename: yup.string<'Geometry'>().optional(),",
+        'shape: ShapeSchema.nullable().optional()',
+        '})',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
   });
 
   it('properly generates custom directive values', async () => {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -837,4 +837,88 @@ describe('zod', () => {
       expect(result.content).toContain(wantContain);
     }
   });
+
+  it('exports as const instead of func', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input Say {
+        phrase: String!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'zod',
+        validationSchemaExportType: 'const',
+      },
+      {}
+    );
+    expect(result.content).toContain('export const SaySchema: z.ZodObject<Properties<Say>> = z.object({');
+  });
+
+  it('generate both input & type, export as const', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      scalar Date
+      scalar Email
+      input UserCreateInput {
+        name: String!
+        date: Date!
+        email: Email!
+      }
+      type User {
+        id: ID!
+        name: String
+        age: Int
+        email: Email
+        isMember: Boolean
+        createdAt: Date!
+      }
+      type Mutation {
+        _empty: String
+      }
+      type Query {
+        _empty: String
+      }
+      type Subscription {
+        _empty: String
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'zod',
+        withObjectType: true,
+        scalarSchemas: {
+          Date: 'z.date()',
+          Email: 'z.string().email()',
+        },
+        validationSchemaExportType: 'const',
+      },
+      {}
+    );
+    const wantContains = [
+      // User Create Input
+      'export const UserCreateInputSchema: z.ZodObject<Properties<UserCreateInput>> = z.object({',
+      'name: z.string(),',
+      'date: z.date(),',
+      'email: z.string().email()',
+      // User
+      'export const UserSchema: z.ZodObject<Properties<User>> = z.object({',
+      "__typename: z.literal('User').optional()",
+      'id: z.string(),',
+      'name: z.string().nullish(),',
+      'age: z.number().nullish(),',
+      'isMember: z.boolean().nullish(),',
+      'email: z.string().email().nullish(),',
+      'createdAt: z.date()',
+    ];
+    for (const wantContain of wantContains) {
+      expect(result.content).toContain(wantContain);
+    }
+
+    for (const wantNotContain of ['Query', 'Mutation', 'Subscription']) {
+      expect(result.content).not.toContain(wantNotContain);
+    }
+  });
 });

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -1,6 +1,5 @@
 import { buildSchema } from 'graphql';
 import { plugin } from '../src/index';
-import { ScalarsMap } from '@graphql-codegen/visitor-plugin-common';
 
 describe('zod', () => {
   test.each([
@@ -797,6 +796,42 @@ describe('zod', () => {
         'export function AnyTypeSchema() {',
         'return z.union([PageTypeSchema, MethodTypeSchema])',
         '}',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
+
+    it('generate union types with single element, export as const', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Square {
+          size: Int
+        }
+        type Circle {
+          radius: Int
+        }
+        union Shape = Circle | Square
+
+        type Geometry {
+          shape: Shape
+        }
+      `);
+
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'zod',
+          withObjectType: true,
+          validationSchemaExportType: 'const',
+        },
+        {}
+      );
+
+      const wantContains = [
+        'export const GeometrySchema: z.ZodObject<Properties<Geometry>> = z.object({',
+        "__typename: z.literal('Geometry').optional(),",
+        'shape: ShapeSchema.nullish()',
       ];
       for (const wantContain of wantContains) {
         expect(result.content).toContain(wantContain);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1757,6 +1757,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/graphlib@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@types/graphlib/-/graphlib-2.1.8.tgz#9edd607e4b863a33b8b78cb08385c0be6896008a"
+  integrity sha512-8nbbyD3zABRA9ePoBgAl2ym8cIwKQXTfv1gaIRTdY99yEOCaHfmjBeRp+BIemS8NtOqoWK7mfzWxjNrxLK3T5w==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -3199,6 +3204,13 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
+
 graphql-config@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-5.0.2.tgz#7e962f94ccddcc2ee0aa71d75cf4491ec5092bdb"
@@ -4234,7 +4246,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
+lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5356,12 +5368,17 @@ to-regex-range@^5.0.1:
 toposort@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
-  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+ts-dedent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
 ts-jest@29.1.0:
   version "29.1.0"


### PR DESCRIPTION
fix: https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/pull/382#issuecomment-1579631051

I've added logic to graph the dependencies that GraphQL schemas have, and perform a [topological sort](https://en.wikipedia.org/wiki/Topological_sorting) based on that in order to resolve the dependencies. Normally, this sort is effective when there are no circular references, but I have made some modifications because users may generate code from schemas that have circular references.