### PR TITLE
fix #386

### DIFF
--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -212,9 +212,8 @@ const generateFieldTypeMyZodSchema = (
     }
     const appliedDirectivesGen = applyDirectives(config, field, gen);
     if (isNonNullType(parentType)) {
-      if (config.notAllowEmptyString === true) {
-        const tsType = visitor.getScalarType(type.name.value);
-        if (tsType === 'string') return `${gen}.min(1)`;
+      if (visitor.shouldEmitAsNotAllowEmptyString(type.name.value)) {
+        return `${gen}.min(1)`;
       }
       return appliedDirectivesGen;
     }

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -262,9 +262,8 @@ const generateFieldTypeYupSchema = (
   if (isNamedType(type)) {
     const gen = generateNameNodeYupSchema(config, visitor, type.name);
     if (isNonNullType(parentType)) {
-      if (config.notAllowEmptyString === true) {
-        const tsType = visitor.getScalarType(type.name.value);
-        if (tsType === 'string') return `${gen}.required()`;
+      if (visitor.shouldEmitAsNotAllowEmptyString(type.name.value)) {
+        return `${gen}.required()`;
       }
       return `${gen}.nonNullable()`;
     }

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -222,9 +222,8 @@ const generateFieldTypeZodSchema = (
     }
     const appliedDirectivesGen = applyDirectives(config, field, gen);
     if (isNonNullType(parentType)) {
-      if (config.notAllowEmptyString === true) {
-        const tsType = visitor.getScalarType(type.name.value);
-        if (tsType === 'string') return `${appliedDirectivesGen}.min(1)`;
+      if (visitor.shouldEmitAsNotAllowEmptyString(type.name.value)) {
+        return `${appliedDirectivesGen}.min(1)`;
       }
       return appliedDirectivesGen;
     }

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -1,4 +1,5 @@
 import { buildSchema } from 'graphql';
+import dedent from 'ts-dedent';
 
 import { plugin } from '../src/index';
 
@@ -295,6 +296,37 @@ describe('myzod', () => {
     for (const wantContain of wantContains) {
       expect(result.content).toContain(wantContain);
     }
+  });
+
+  it('with notAllowEmptyString issue #386', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input InputOne {
+        field: InputNested!
+      }
+
+      input InputNested {
+        field: String!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'myzod',
+        notAllowEmptyString: true,
+        scalars: {
+          ID: 'string',
+        },
+      },
+      {}
+    );
+    const wantContain = dedent`
+    export function InputNestedSchema(): myzod.Type<InputNested> {
+      return myzod.object({
+        field: myzod.string().min(1)
+      })
+    }`;
+    expect(result.content).toContain(wantContain);
   });
 
   it('with scalarSchemas', async () => {

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -1,4 +1,5 @@
 import { buildSchema } from 'graphql';
+import dedent from 'ts-dedent';
 
 import { plugin } from '../src/index';
 
@@ -292,6 +293,37 @@ describe('yup', () => {
     for (const wantContain of wantContains) {
       expect(result.content).toContain(wantContain);
     }
+  });
+
+  it('with notAllowEmptyString issue #386', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input InputOne {
+        field: InputNested!
+      }
+
+      input InputNested {
+        field: String!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'yup',
+        notAllowEmptyString: true,
+        scalars: {
+          ID: 'string',
+        },
+      },
+      {}
+    );
+    const wantContain = dedent`
+    export function InputNestedSchema(): yup.ObjectSchema<InputNested> {
+      return yup.object({
+        field: yup.string().defined().required()
+      })
+    }`;
+    expect(result.content).toContain(wantContain);
   });
 
   it('with scalarSchemas', async () => {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -1,4 +1,5 @@
 import { buildSchema } from 'graphql';
+import { dedent } from 'ts-dedent';
 
 import { plugin } from '../src/index';
 
@@ -295,6 +296,37 @@ describe('zod', () => {
     for (const wantContain of wantContains) {
       expect(result.content).toContain(wantContain);
     }
+  });
+
+  it('with notAllowEmptyString issue #386', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input InputOne {
+        field: InputNested!
+      }
+
+      input InputNested {
+        field: String!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'zod',
+        notAllowEmptyString: true,
+        scalars: {
+          ID: 'string',
+        },
+      },
+      {}
+    );
+    const wantContain = dedent`
+    export function InputNestedSchema(): z.ZodObject<Properties<InputNested>> {
+      return z.object({
+        field: z.string().min(1)
+      })
+    }`;
+    expect(result.content).toContain(wantContain);
   });
 
   it('with scalarSchemas', async () => {


### PR DESCRIPTION
for #386

- Replace direct checks for `notAllowEmptyString` configuration with a new method `shouldEmitAsNotAllowEmptyString` in the `Visitor` class.
- The new method `shouldEmitAsNotAllowEmptyString` encapsulates the check for the `notAllowEmptyString` configuration and the type of the variable, making the code cleaner and more readable.
- The changes have been made across `myzod`, `yup`, and `zod` schemas.