### PR TITLE
Input objects support default values

### DIFF
--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -403,6 +403,40 @@ describe('zod', () => {
     expect(result.content).toContain('export function SayISchema(): z.ZodObject<Properties<SayI>> {');
   });
 
+  it('with default input values', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      enum PageType {
+        PUBLIC
+        BASIC_AUTH
+      }
+      input PageInput {
+        pageType: PageType! = PUBLIC
+        greeting: String = "Hello"
+        score: Int = 100
+        ratio: Float = 0.5
+        isMember: Boolean = true
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'zod',
+        importFrom: './types',
+      },
+      {}
+    );
+
+    expect(result.content).toContain('export const PageTypeSchema = z.nativeEnum(PageType)');
+    expect(result.content).toContain('export function PageInputSchema(): z.ZodObject<Properties<PageInput>>');
+
+    expect(result.content).toContain('pageType: PageTypeSchema.default("PUBLIC")');
+    expect(result.content).toContain('greeting: z.string().default("Hello").nullish()');
+    expect(result.content).toContain('score: z.number().default(100).nullish()');
+    expect(result.content).toContain('ratio: z.number().default(0.5).nullish()');
+    expect(result.content).toContain('isMember: z.boolean().default(true).nullish()');
+  });
+
   describe('issues #19', () => {
     it('string field', async () => {
       const schema = buildSchema(/* GraphQL */ `


### PR DESCRIPTION
Input objects support default values and we'd like to get this supported in the generated schema: http://spec.graphql.org/June2018/#sec-Input-Objects

```graphql
enum PageType {
  PUBLIC
  BASIC_AUTH
}
input PageInput {
  pageType: PageType! = PUBLIC
  greeting: String = "Hello"
  score: Int = 100
  ratio: Float = 0.5
  isMember: Boolean = true
}
```

Should be able to generate the following:

```
export const PageTypeSchema = z.nativeEnum(PageType);

export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
  return z.object({
    pageType: PageTypeSchema.default("PUBLIC"),
    greeting: z.string().default("Hello").nullish(),
    score: z.number().default(100).nullish(),
    ratio: z.number().default(0.5).nullish(),
    isMember: z.boolean().default(true).nullish()
  })
}
```

This PR is not complete, but I wanted to start a conversation about supporting this.

To make this a complete PR there needs to happen a few things in my opinion:

- [ ] Decide how to handle more complex default values like lists / objects (can we omit this for now?)
- [ ] How to handle nullish values here, should we keep the 'nullish' here?
- [ ] Implement similar functionality for the other schema's