### PR TITLE
Add support for InterfaceTypeDefinition

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -195,6 +195,24 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    */
   withObjectType?: boolean;
   /**
+   * @description Generates validation schema with GraphQL type interfaces.
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/types.ts:
+   *     plugins:
+   *       - typescript
+   *   path/to/schemas.ts:
+   *     plugins:
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       schema: yup
+   *       withInterfaceType: true
+   * ```
+   */
+  withInterfaceType?: boolean;
+  /**
    * @description Specify validation schema export type.
    * @default function
    *

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -4,6 +4,7 @@ import {
   DefinitionNode,
   DocumentNode,
   GraphQLSchema,
+  InterfaceTypeDefinitionNode,
   isSpecifiedScalarType,
   ListTypeNode,
   NamedTypeNode,
@@ -21,6 +22,7 @@ export const isNamedType = (typ?: TypeNode): typ is NamedTypeNode => typ?.kind =
 export const isInput = (kind: string) => kind.includes('Input');
 
 type ObjectTypeDefinitionFn = (node: ObjectTypeDefinitionNode) => any;
+type InterfaceTypeDefinitionFn = (node: InterfaceTypeDefinitionNode) => any;
 
 export const ObjectTypeDefinitionBuilder = (
   useObjectTypes: boolean | undefined,
@@ -31,6 +33,16 @@ export const ObjectTypeDefinitionBuilder = (
     if (/^(Query|Mutation|Subscription)$/.test(node.name.value)) {
       return;
     }
+    return callback(node);
+  };
+};
+
+export const InterfaceTypeDefinitionBuilder = (
+  useInterfaceTypes: boolean | undefined,
+  callback: InterfaceTypeDefinitionFn
+): InterfaceTypeDefinitionFn | undefined => {
+  if (!useInterfaceTypes) return undefined;
+  return node => {
     return callback(node);
   };
 };

--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -58,7 +58,7 @@ export class MyZodSchemaVisitor extends BaseSchemaVisitor {
         this.importTypes.push(name);
 
         // Building schema for field arguments.
-        const argumentBlocks = this.buildObjectTypeDefinitionArguments(node, visitor);
+        const argumentBlocks = this.buildTypeDefinitionArguments(node, visitor);
         const appendArguments = argumentBlocks ? '\n' + argumentBlocks : '';
 
         // Building schema for fields.

--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -89,14 +89,7 @@ export class MyZodSchemaVisitor extends BaseSchemaVisitor {
                 .export()
                 .asKind('function')
                 .withName(`${name}Schema(): myzod.Type<${name}>`)
-                .withBlock(
-                  [
-                    indent(`return myzod.object({`),
-                    indent(`__typename: myzod.literal('${node.name.value}').optional(),`, 2),
-                    shape,
-                    indent('})'),
-                  ].join('\n')
-                ).string + appendArguments
+                .withBlock([indent(`return myzod.object({`), shape, indent('})')].join('\n')).string + appendArguments
             );
         }
       }),

--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -5,6 +5,7 @@ import {
   GraphQLSchema,
   InputObjectTypeDefinitionNode,
   InputValueDefinitionNode,
+  InterfaceTypeDefinitionNode,
   NameNode,
   ObjectTypeDefinitionNode,
   TypeNode,
@@ -15,7 +16,14 @@ import { ValidationSchemaPluginConfig } from '../config';
 import { buildApi, formatDirectiveConfig } from '../directive';
 import { BaseSchemaVisitor } from '../schema_visitor';
 import { Visitor } from '../visitor';
-import { isInput, isListType, isNamedType, isNonNullType, ObjectTypeDefinitionBuilder } from './../graphql';
+import {
+  InterfaceTypeDefinitionBuilder,
+  isInput,
+  isListType,
+  isNamedType,
+  isNonNullType,
+  ObjectTypeDefinitionBuilder,
+} from './../graphql';
 
 const anySchema = `definedNonNullAnySchema`;
 
@@ -47,6 +55,51 @@ export class MyZodSchemaVisitor extends BaseSchemaVisitor {
         this.importTypes.push(name);
         return this.buildInputFields(node.fields ?? [], visitor, name);
       },
+    };
+  }
+
+  get InterfaceTypeDefinition() {
+    return {
+      leave: InterfaceTypeDefinitionBuilder(this.config.withInterfaceType, (node: InterfaceTypeDefinitionNode) => {
+        const visitor = this.createVisitor('output');
+        const name = visitor.convertName(node.name.value);
+        this.importTypes.push(name);
+
+        // Building schema for field arguments.
+        const argumentBlocks = this.buildTypeDefinitionArguments(node, visitor);
+        const appendArguments = argumentBlocks ? '\n' + argumentBlocks : '';
+
+        // Building schema for fields.
+        const shape = node.fields?.map(field => generateFieldMyZodSchema(this.config, visitor, field, 2)).join(',\n');
+
+        switch (this.config.validationSchemaExportType) {
+          case 'const':
+            return (
+              new DeclarationBlock({})
+                .export()
+                .asKind('const')
+                .withName(`${name}Schema: myzod.Type<${name}>`)
+                .withContent([`myzod.object({`, shape, '})'].join('\n')).string + appendArguments
+            );
+
+          case 'function':
+          default:
+            return (
+              new DeclarationBlock({})
+                .export()
+                .asKind('function')
+                .withName(`${name}Schema(): myzod.Type<${name}>`)
+                .withBlock(
+                  [
+                    indent(`return myzod.object({`),
+                    indent(`__typename: myzod.literal('${node.name.value}').optional(),`, 2),
+                    shape,
+                    indent('})'),
+                  ].join('\n')
+                ).string + appendArguments
+            );
+        }
+      }),
     };
   }
 
@@ -270,6 +323,7 @@ const generateNameNodeMyZodSchema = (
   const converter = visitor.getNameNodeConverter(node);
 
   switch (converter?.targetKind) {
+    case 'InterfaceTypeDefinition':
     case 'InputObjectTypeDefinition':
     case 'ObjectTypeDefinition':
     case 'UnionTypeDefinition':
@@ -283,7 +337,12 @@ const generateNameNodeMyZodSchema = (
       }
     case 'EnumTypeDefinition':
       return `${converter.convertName()}Schema`;
+    case 'ScalarTypeDefinition':
+      return myzod4Scalar(config, visitor, node.value);
     default:
+      if (converter?.targetKind) {
+        console.warn('Unknown target kind', converter.targetKind);
+      }
       return myzod4Scalar(config, visitor, node.value);
   }
 };

--- a/src/schema_visitor.ts
+++ b/src/schema_visitor.ts
@@ -1,4 +1,10 @@
-import { FieldDefinitionNode, GraphQLSchema, InputValueDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
+import {
+  FieldDefinitionNode,
+  GraphQLSchema,
+  InputValueDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+} from 'graphql';
 
 import { ValidationSchemaPluginConfig } from './config';
 import { SchemaVisitor } from './types';
@@ -39,7 +45,10 @@ export abstract class BaseSchemaVisitor implements SchemaVisitor {
     name: string
   ): string;
 
-  protected buildObjectTypeDefinitionArguments(node: ObjectTypeDefinitionNode, visitor: Visitor) {
+  protected buildTypeDefinitionArguments(
+    node: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+    visitor: Visitor
+  ) {
     return visitor.buildArgumentsSchemaBlock(node, (typeName, field) => {
       this.importTypes.push(typeName);
       return this.buildInputFields(field.arguments ?? [], visitor, typeName);

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,5 +1,12 @@
 import { TsVisitor } from '@graphql-codegen/typescript';
-import { FieldDefinitionNode, GraphQLSchema, NameNode, ObjectTypeDefinitionNode, specifiedScalarTypes } from 'graphql';
+import {
+  FieldDefinitionNode,
+  GraphQLSchema,
+  InterfaceTypeDefinitionNode,
+  NameNode,
+  ObjectTypeDefinitionNode,
+  specifiedScalarTypes,
+} from 'graphql';
 
 import { ValidationSchemaPluginConfig } from './config';
 
@@ -52,7 +59,7 @@ export class Visitor extends TsVisitor {
   }
 
   public buildArgumentsSchemaBlock(
-    node: ObjectTypeDefinitionNode,
+    node: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
     callback: (typeName: string, field: FieldDefinitionNode) => string
   ) {
     const fieldsWithArguments = node.fields?.filter(field => field.arguments && field.arguments.length > 0) ?? [];

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -43,7 +43,11 @@ export class Visitor extends TsVisitor {
     if (this.scalarDirection === 'both') {
       return null;
     }
-    return this.scalars[scalarName][this.scalarDirection];
+    const scalar = this.scalars[scalarName];
+    if (!scalar) {
+      throw new Error(`Unknown scalar ${scalarName}`);
+    }
+    return scalar[this.scalarDirection];
   }
 
   public shouldEmitAsNotAllowEmptyString(name: string): boolean {

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -64,7 +64,7 @@ export class YupSchemaVisitor extends BaseSchemaVisitor {
         this.importTypes.push(name);
 
         // Building schema for field arguments.
-        const argumentBlocks = this.buildObjectTypeDefinitionArguments(node, visitor);
+        const argumentBlocks = this.buildTypeDefinitionArguments(node, visitor);
         const appendArguments = argumentBlocks ? '\n' + argumentBlocks : '';
 
         // Building schema for fields.

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -74,7 +74,7 @@ export class ZodSchemaVisitor extends BaseSchemaVisitor {
         this.importTypes.push(name);
 
         // Building schema for field arguments.
-        const argumentBlocks = this.buildObjectTypeDefinitionArguments(node, visitor);
+        const argumentBlocks = this.buildTypeDefinitionArguments(node, visitor);
         const appendArguments = argumentBlocks ? '\n' + argumentBlocks : '';
 
         // Building schema for fields.
@@ -279,6 +279,7 @@ const generateNameNodeZodSchema = (config: ValidationSchemaPluginConfig, visitor
   const converter = visitor.getNameNodeConverter(node);
 
   switch (converter?.targetKind) {
+    case 'InterfaceTypeDefinition':
     case 'InputObjectTypeDefinition':
     case 'ObjectTypeDefinition':
     case 'UnionTypeDefinition':

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -339,7 +339,12 @@ const generateNameNodeZodSchema = (config: ValidationSchemaPluginConfig, visitor
       }
     case 'EnumTypeDefinition':
       return `${converter.convertName()}Schema`;
+    case 'ScalarTypeDefinition':
+      return zod4Scalar(config, visitor, node.value);
     default:
+      if (converter?.targetKind) {
+        console.warn('Unknown targetKind', converter?.targetKind);
+      }
       return zod4Scalar(config, visitor, node.value);
   }
 };

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -545,6 +545,88 @@ describe('myzod', () => {
         expect(result.content).toContain(wantContain);
       }
     });
+    it('generate object type contains interface type', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          title: String!
+          author: Author!
+        }
+
+        type Textbook implements Book {
+          title: String!
+          author: Author!
+          courses: [String!]!
+        }
+
+        type ColoringBook implements Book {
+          title: String!
+          author: Author!
+          colors: [String!]!
+        }
+
+        type Author {
+          books: [Book!]
+          name: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withInterfaceType: true,
+          withObjectType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        [
+          'export function BookSchema(): myzod.Type<Book> {',
+          'return myzod.object({',
+          'title: myzod.string(),',
+          'author: AuthorSchema()',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function TextbookSchema(): myzod.Type<Textbook> {',
+          'return myzod.object({',
+          "__typename: myzod.literal('Textbook').optional(),",
+          'title: myzod.string(),',
+          'author: AuthorSchema(),',
+          'courses: myzod.array(myzod.string())',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function ColoringBookSchema(): myzod.Type<ColoringBook> {',
+          'return myzod.object({',
+          "__typename: myzod.literal('ColoringBook').optional(),",
+          'title: myzod.string(),',
+          'author: AuthorSchema(),',
+          'colors: myzod.array(myzod.string())',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function AuthorSchema(): myzod.Type<Author> {',
+          'return myzod.object({',
+          "__typename: myzod.literal('Author').optional()",
+          'books: myzod.array(BookSchema()).optional().nullable()',
+          'name: myzod.string().optional().nullable()',
+          '})',
+          '}',
+        ],
+      ];
+      for (const wantContain of wantContains) {
+        for (const wantContainLine of wantContain) {
+          expect(result.content).toContain(wantContainLine);
+        }
+      }
+    });
   });
 
   describe('with withObjectType', () => {

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -511,6 +511,34 @@ describe('myzod', () => {
       expect(result.content).not.toContain('export function UserSchema(): myzod.Type<User> {');
     });
 
+    it('generate if withInterfaceType true', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          title: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withInterfaceType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        'export function BookSchema(): myzod.Type<Book> {',
+        'title: myzod.string().optional().nullable()',
+      ];
+      const wantNotContains = ["__typename: myzod.literal('Book')"];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+      for (const wantNotContain of wantNotContains) {
+        expect(result.content).not.toContain(wantNotContain);
+      }
+    });
+
     it('generate interface type contains interface type', async () => {
       const schema = buildSchema(/* GraphQL */ `
         interface Book {

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -492,6 +492,61 @@ describe('myzod', () => {
     });
   });
 
+  describe('with withInterfaceType', () => {
+    it('not generate if withObjectType false', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface User {
+          id: ID!
+          name: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+        },
+        {}
+      );
+      expect(result.content).not.toContain('export function UserSchema(): myzod.Type<User> {');
+    });
+
+    it('generate interface type contains interface type', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          author: Author
+          title: String
+        }
+
+        interface Author {
+          books: [Book]
+          name: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'myzod',
+          withInterfaceType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        'export function AuthorSchema(): myzod.Type<Author> {',
+        'books: myzod.array(BookSchema().nullable()).optional().nullable(),',
+        'name: myzod.string().optional().nullable()',
+
+        'export function BookSchema(): myzod.Type<Book> {',
+        'author: AuthorSchema().optional().nullable(),',
+        'title: myzod.string().optional().nullable()',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
+  });
+
   describe('with withObjectType', () => {
     it('not generate if withObjectType false', async () => {
       const schema = buildSchema(/* GraphQL */ `

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -462,6 +462,89 @@ describe('yup', () => {
         expect(result.content).not.toContain(wantNotContain);
       }
     });
+    it('generate object type contains interface type', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          title: String!
+          author: Author!
+        }
+
+        type Textbook implements Book {
+          title: String!
+          author: Author!
+          courses: [String!]!
+        }
+
+        type ColoringBook implements Book {
+          title: String!
+          author: Author!
+          colors: [String!]!
+        }
+
+        type Author {
+          books: [Book!]
+          name: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'yup',
+          withInterfaceType: true,
+          withObjectType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        [
+          'export function BookSchema(): yup.ObjectSchema<Book> {',
+          'return yup.object({',
+          'title: yup.string().defined().nonNullable(),',
+          'author: AuthorSchema().nonNullable()',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function TextbookSchema(): yup.ObjectSchema<Textbook> {',
+          'return yup.object({',
+          "__typename: yup.string<'Textbook'>().optional(),",
+          'title: yup.string().defined().nonNullable(),',
+          'author: AuthorSchema().nonNullable(),',
+          'courses: yup.array(yup.string().defined().nonNullable()).defined()',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function ColoringBookSchema(): yup.ObjectSchema<ColoringBook> {',
+          'return yup.object({',
+          "__typename: yup.string<'ColoringBook'>().optional(),",
+          'title: yup.string().defined().nonNullable(),',
+          'author: AuthorSchema().nonNullable(),',
+          'colors: yup.array(yup.string().defined().nonNullable()).defined()',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function AuthorSchema(): yup.ObjectSchema<Author> {',
+          'return yup.object({',
+          "__typename: yup.string<'Author'>().optional(),",
+          'books: yup.array(BookSchema().nonNullable()).defined().nullable().optional(),',
+          'name: yup.string().defined().nullable().optional()',
+          '})',
+          '}',
+        ],
+      ];
+
+      for (const wantContain of wantContains) {
+        for (const wantContainLine of wantContain) {
+          expect(result.content).toContain(wantContainLine);
+        }
+      }
+    });
   });
 
   describe('with withObjectType', () => {

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -415,6 +415,34 @@ describe('yup', () => {
       expect(result.content).not.toContain('export function UserSchema(): yup.ObjectSchema<User> {');
     });
 
+    it('generate if withInterfaceType true', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          title: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'yup',
+          withInterfaceType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        'export function BookSchema(): yup.ObjectSchema<Book> {',
+        'title: yup.string().defined().nullable().optional()',
+      ];
+      const wantNotContains = ["__typename: yup.string<'Book'>().optional()"];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+      for (const wantNotContain of wantNotContains) {
+        expect(result.content).not.toContain(wantNotContain);
+      }
+    });
+
     it('generate interface type contains interface type', async () => {
       const schema = buildSchema(/* GraphQL */ `
         interface Book {
@@ -448,11 +476,11 @@ describe('yup', () => {
 
         'export function BookSchema(): yup.ObjectSchema<Book> {',
         'author: AuthorSchema().nullable().optional(),',
-        'title: yup.string().defined().nonNullable()',
+        'title: yup.string().defined().nullable().optional()',
 
         'export function Book2Schema(): yup.ObjectSchema<Book2> {',
         'author: AuthorSchema().nonNullable(),',
-        'title: yup.string().defined().nullable().optional()',
+        'title: yup.string().defined().nonNullable()',
       ];
       for (const wantContain of wantContains) {
         expect(result.content).toContain(wantContain);

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -583,6 +583,34 @@ describe('zod', () => {
       expect(result.content).not.toContain('export function UserSchema(): z.ZodObject<Properties<User>>');
     });
 
+    it('generate if withInterfaceType true', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          title: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'zod',
+          withInterfaceType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        'export function BookSchema(): z.ZodObject<Properties<Book>> {',
+        'title: z.string().nullish()',
+      ];
+      const wantNotContains = ["__typename: z.literal('Book')"];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+      for (const wantNotContain of wantNotContains) {
+        expect(result.content).not.toContain(wantNotContain);
+      }
+    });
+
     it('generate interface type contains interface type', async () => {
       const schema = buildSchema(/* GraphQL */ `
         interface Book {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -1,5 +1,6 @@
 import { getCachedDocumentNodeFromSchema } from '@graphql-codegen/plugin-helpers';
 import { buildClientSchema, buildSchema, introspectionFromSchema, isSpecifiedScalarType } from 'graphql';
+import { join } from 'path';
 import { dedent } from 'ts-dedent';
 
 import { plugin } from '../src/index';
@@ -559,6 +560,145 @@ describe('zod', () => {
       ];
       for (const wantContain of wantContains) {
         expect(result.content).toContain(wantContain);
+      }
+    });
+  });
+
+  describe('with withInterfaceType', () => {
+    it('not generate if withObjectType false', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface User {
+          id: ID!
+          name: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'zod',
+        },
+        {}
+      );
+      expect(result.content).not.toContain('export function UserSchema(): z.ZodObject<Properties<User>>');
+    });
+
+    it('generate interface type contains interface type', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          author: Author
+          title: String
+        }
+
+        interface Author {
+          books: [Book]
+          name: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'zod',
+          withInterfaceType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        'export function AuthorSchema(): z.ZodObject<Properties<Author>> {',
+        'books: z.array(BookSchema().nullable()).nullish(),',
+        'name: z.string().nullish()',
+
+        'export function BookSchema(): z.ZodObject<Properties<Book>> {',
+        'author: AuthorSchema().nullish(),',
+        'title: z.string().nullish()',
+      ];
+      for (const wantContain of wantContains) {
+        expect(result.content).toContain(wantContain);
+      }
+    });
+
+    it('generate object type contains interface type', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        interface Book {
+          title: String!
+          author: Author!
+        }
+
+        type Textbook implements Book {
+          title: String!
+          author: Author!
+          courses: [String!]!
+        }
+
+        type ColoringBook implements Book {
+          title: String!
+          author: Author!
+          colors: [String!]!
+        }
+
+        type Author {
+          books: [Book!]
+          name: String
+        }
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'zod',
+          withInterfaceType: true,
+          withObjectType: true,
+        },
+        {}
+      );
+      const wantContains = [
+        [
+          'export function BookSchema(): z.ZodObject<Properties<Book>> {',
+          'return z.object({',
+          'title: z.string(),',
+          'author: AuthorSchema()',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function TextbookSchema(): z.ZodObject<Properties<Textbook>> {',
+          'return z.object({',
+          "__typename: z.literal('Textbook').optional(),",
+          'title: z.string(),',
+          'author: AuthorSchema(),',
+          'courses: z.array(z.string())',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function ColoringBookSchema(): z.ZodObject<Properties<ColoringBook>> {',
+          'return z.object({',
+          "__typename: z.literal('ColoringBook').optional(),",
+          'title: z.string(),',
+          'author: AuthorSchema(),',
+          'colors: z.array(z.string())',
+          '})',
+          '}',
+        ],
+
+        [
+          'export function AuthorSchema(): z.ZodObject<Properties<Author>> {',
+          'return z.object({',
+          "__typename: z.literal('Author').optional()",
+          'books: z.array(BookSchema()).nullish()',
+          'name: z.string().nullish()',
+          '})',
+          '}',
+        ],
+      ];
+
+      for (const wantContain of wantContains) {
+        for (const wantContainLine of wantContain) {
+          expect(result.content).toContain(wantContainLine);
+        }
       }
     });
   });


### PR DESCRIPTION
Solves issue #474 

Add config option `withInterfaceType` to make validation schema generation of  `InterfaceTypeDefinition` optional.

Log a warning if an unsupported `TargetKind`  is used in a GQL Schema. By default, unknown target types handle everything as `Scalar`. If the `Scalar` is unknown, an  Exception will be thrown with an error message about the unknown `Scalar`.

The difference with `InterfaceTypeDefinition`  compared to `ObjectTypeDefinition` is the lack of `__typename` (and `Query`, `Mutation` and `Subscription`

Added test cases similar to some of the `withObjectType` test cases. 

