### PR TITLE
added support for URI format in directive config

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ generates:
           # Replace $1 with specified `startsWith` argument value of the constraint directive
           startsWith: [matches, /^$1/]
           format:
+            # This example means `validation-schema: directive-arg`
+            # directive-arg is supported String and Enum.
             email: email
 ```
 
@@ -279,6 +281,8 @@ generates:
           # Replace $1 with specified `startsWith` argument value of the constraint directive
           startsWith: [regex, /^$1/, message]
           format:
+            # This example means `validation-schema: directive-arg`
+            # directive-arg is supported String and Enum.
             email: email
 ```
 

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -146,7 +146,7 @@ function buildApiFromDirectiveArguments(config: FormattedDirectiveArguments, arg
 }
 
 function buildApiFromDirectiveObjectArguments(config: FormattedDirectiveObjectArguments, argValue: ConstValueNode): string {
-  if (argValue.kind !== Kind.STRING)
+  if (argValue.kind !== Kind.STRING && argValue.kind !== Kind.ENUM)
     return '';
 
   const validationSchema = config[argValue.value];

--- a/tests/directive.spec.ts
+++ b/tests/directive.spec.ts
@@ -575,6 +575,25 @@ describe('format directive config', () => {
         },
         want: `.required("message").min(100).email()`,
       },
+      {
+        name: 'enum',
+        args: {
+          config: {
+            constraint: {
+              format: {
+                URI: ['uri'],
+              },
+            },
+          },
+          args: [
+            // @constraint(format: EMAIL)
+            buildConstDirectiveNodes('constraint', {
+              format: 'URI',
+            }),
+          ],
+        },
+        want: `.uri()`,
+      },
     ];
     for (const tc of cases) {
       it(tc.name, () => {


### PR DESCRIPTION
fixes: https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/issues/611