### PR TITLE
Prevent setting optional/nullish/nullable when a default value is set

### DIFF
--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -275,7 +275,8 @@ function generateFieldTypeMyZodSchema(config: ValidationSchemaPluginConfig, visi
 
     let appliedDirectivesGen = applyDirectives(config, field, gen);
 
-    if (field.kind === Kind.INPUT_VALUE_DEFINITION) {
+    const hasDefaultValue = field.kind === Kind.INPUT_VALUE_DEFINITION && field.defaultValue
+    if (hasDefaultValue) {
       const { defaultValue } = field;
 
       if (defaultValue?.kind === Kind.INT || defaultValue?.kind === Kind.FLOAT || defaultValue?.kind === Kind.BOOLEAN)
@@ -285,7 +286,7 @@ function generateFieldTypeMyZodSchema(config: ValidationSchemaPluginConfig, visi
         appliedDirectivesGen = `${appliedDirectivesGen}.default("${defaultValue.value}")`;
     }
 
-    if (isNonNullType(parentType)) {
+    if (isNonNullType(parentType) || hasDefaultValue) {
       if (visitor.shouldEmitAsNotAllowEmptyString(type.name.value))
         return `${gen}.min(1)`;
 

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -272,7 +272,8 @@ function shapeFields(fields: readonly (FieldDefinitionNode | InputValueDefinitio
     ?.map((field) => {
       let fieldSchema = generateFieldYupSchema(config, visitor, field, 2);
 
-      if (field.kind === Kind.INPUT_VALUE_DEFINITION) {
+      const hasDefaultValue = field.kind === Kind.INPUT_VALUE_DEFINITION && field.defaultValue
+      if (hasDefaultValue) {
         const { defaultValue } = field;
 
         if (
@@ -284,9 +285,11 @@ function shapeFields(fields: readonly (FieldDefinitionNode | InputValueDefinitio
 
         if (defaultValue?.kind === Kind.STRING || defaultValue?.kind === Kind.ENUM)
           fieldSchema = `${fieldSchema}.default("${defaultValue.value}")`;
+
+        fieldSchema = fieldSchema.replace('.nullable()', '')
       }
 
-      if (isNonNullType(field.type))
+      if (isNonNullType(field.type) || hasDefaultValue)
         return fieldSchema;
 
       return `${fieldSchema}.optional()`;

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -288,7 +288,8 @@ function generateFieldTypeZodSchema(config: ValidationSchemaPluginConfig, visito
 
     let appliedDirectivesGen = applyDirectives(config, field, gen);
 
-    if (field.kind === Kind.INPUT_VALUE_DEFINITION) {
+    const hasDefaultValue = field.kind === Kind.INPUT_VALUE_DEFINITION && field.defaultValue
+    if (hasDefaultValue) {
       const { defaultValue } = field;
 
       if (defaultValue?.kind === Kind.INT || defaultValue?.kind === Kind.FLOAT || defaultValue?.kind === Kind.BOOLEAN)
@@ -298,7 +299,7 @@ function generateFieldTypeZodSchema(config: ValidationSchemaPluginConfig, visito
         appliedDirectivesGen = `${appliedDirectivesGen}.default("${defaultValue.value}")`;
     }
 
-    if (isNonNullType(parentType)) {
+    if (isNonNullType(parentType) || hasDefaultValue) {
       if (visitor.shouldEmitAsNotAllowEmptyString(type.name.value))
         return `${appliedDirectivesGen}.min(1)`;
 

--- a/tests/myzod.spec.ts
+++ b/tests/myzod.spec.ts
@@ -1163,9 +1163,9 @@ describe('myzod', () => {
     expect(result.content).toContain('export function PageInputSchema(): myzod.Type<PageInput>');
 
     expect(result.content).toContain('pageType: PageTypeSchema.default("PUBLIC")');
-    expect(result.content).toContain('greeting: myzod.string().default("Hello").optional().nullable()');
-    expect(result.content).toContain('score: myzod.number().default(100).optional().nullable()');
-    expect(result.content).toContain('ratio: myzod.number().default(0.5).optional().nullable()');
-    expect(result.content).toContain('isMember: myzod.boolean().default(true).optional().nullable()');
+    expect(result.content).toContain('greeting: myzod.string().default("Hello")');
+    expect(result.content).toContain('score: myzod.number().default(100)');
+    expect(result.content).toContain('ratio: myzod.number().default(0.5)');
+    expect(result.content).toContain('isMember: myzod.boolean().default(true)');
   });
 });

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -1097,9 +1097,9 @@ describe('yup', () => {
     expect(result.content).toContain('export function PageInputSchema(): yup.ObjectSchema<PageInput>');
 
     expect(result.content).toContain('pageType: PageTypeSchema.nonNullable().default("PUBLIC")');
-    expect(result.content).toContain('greeting: yup.string().defined().nullable().default("Hello").optional()');
-    expect(result.content).toContain('score: yup.number().defined().nullable().default(100).optional()');
-    expect(result.content).toContain('ratio: yup.number().defined().nullable().default(0.5).optional()');
-    expect(result.content).toContain('isMember: yup.boolean().defined().nullable().default(true).optional()');
+    expect(result.content).toContain('greeting: yup.string().defined().default("Hello")');
+    expect(result.content).toContain('score: yup.number().defined().default(100)');
+    expect(result.content).toContain('ratio: yup.number().defined().default(0.5)');
+    expect(result.content).toContain('isMember: yup.boolean().defined().default(true)');
   });
 });

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -427,10 +427,10 @@ describe('zod', () => {
     expect(result.content).toContain('export function PageInputSchema(): z.ZodObject<Properties<PageInput>>');
 
     expect(result.content).toContain('pageType: PageTypeSchema.default("PUBLIC")');
-    expect(result.content).toContain('greeting: z.string().default("Hello").nullish()');
-    expect(result.content).toContain('score: z.number().default(100).nullish()');
-    expect(result.content).toContain('ratio: z.number().default(0.5).nullish()');
-    expect(result.content).toContain('isMember: z.boolean().default(true).nullish()');
+    expect(result.content).toContain('greeting: z.string().default("Hello")');
+    expect(result.content).toContain('score: z.number().default(100)');
+    expect(result.content).toContain('ratio: z.number().default(0.5)');
+    expect(result.content).toContain('isMember: z.boolean().default(true)');
   });
 
   describe('issues #19', () => {


### PR DESCRIPTION
When a default value is set, it can no longer be optional, nullable or nullish, otherwise the default value won't actually be used.