### PR TITLE
maintenance: update pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          package_json_file: ./package.json
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -84,5 +84,6 @@
     "vitest": "^1.0.0",
     "yup": "1.4.0",
     "zod": "3.23.8"
-  }
+  },
+  "packageManager": "pnpm@9.0.2"
 }


### PR DESCRIPTION
## Problem

Currently, when dependabot runs CI, the following error occurs:

```
Run pnpm install --frozen-lockfile
 WARN  Ignoring not compatible lockfile at /home/runner/work/graphql-codegen-typescript-validation-schema/graphql-codegen-typescript-validation-schema/pnpm-lock.yaml
 ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
Error: Process completed with exit code 1.
```

ref: https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/actions/runs/9271635994/job/25507513605

pnpm-lock.yaml seems to be incompatible, but that was because the version of pnpm running in CI is older.

## Solution

- Bump up the pnpm version to v9. 
- Manage the pnpm version in package.json 
    - pnpm is available with `corepack enable`.
    - You can also update the pnpm version with dependabot if you do it this way.
- Refer to it in CI.