### PR TITLE
feat: minimal implementation to support valibot

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -81,3 +81,26 @@ generates:
                 email: email
           scalars:
             ID: string
+  example/valibot/schemas.ts:
+    plugins:
+      - ./dist/main/index.js:
+          schema: valibot
+          importFrom: ../types
+          withObjectType: true
+          directives:
+            # Write directives like
+            #
+            # directive:
+            #   arg1: schemaApi
+            #   arg2: ["schemaApi2", "Hello $1"]
+            #
+            # See more examples in `./tests/directive.spec.ts`
+            # https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/blob/main/tests/directive.spec.ts
+            constraint:
+              minLength: minLength
+              # Replace $1 with specified `startsWith` argument value of the constraint directive
+              startsWith: [regex, /^$1/, message]
+              format:
+                email: email
+          scalars:
+            ID: string

--- a/example/valibot/schemas.ts
+++ b/example/valibot/schemas.ts
@@ -1,0 +1,130 @@
+import * as v from 'valibot'
+import { Admin, AttributeInput, ButtonComponentType, ComponentInput, DropDownComponentInput, EventArgumentInput, EventInput, EventOptionType, Guest, HttpInput, HttpMethod, LayoutInput, MyType, MyTypeFooArgs, Namer, PageInput, PageType, User } from '../types'
+
+export const ButtonComponentTypeSchema = v.enum_(ButtonComponentType);
+
+export const EventOptionTypeSchema = v.enum_(EventOptionType);
+
+export const HttpMethodSchema = v.enum_(HttpMethod);
+
+export const PageTypeSchema = v.enum_(PageType);
+
+export function AdminSchema(): v.GenericSchema<Admin> {
+  return v.object({
+    __typename: v.optional(v.literal('Admin')),
+    lastModifiedAt: v.nullish(v.any())
+  })
+}
+
+export function AttributeInputSchema(): v.GenericSchema<AttributeInput> {
+  return v.object({
+    key: v.nullish(v.string()),
+    val: v.nullish(v.string())
+  })
+}
+
+export function ComponentInputSchema(): v.GenericSchema<ComponentInput> {
+  return v.object({
+    child: v.lazy(() => v.nullish(ComponentInputSchema())),
+    childrens: v.nullish(v.array(v.lazy(() => v.nullable(ComponentInputSchema())))),
+    event: v.lazy(() => v.nullish(EventInputSchema())),
+    name: v.string(),
+    type: ButtonComponentTypeSchema
+  })
+}
+
+export function DropDownComponentInputSchema(): v.GenericSchema<DropDownComponentInput> {
+  return v.object({
+    dropdownComponent: v.lazy(() => v.nullish(ComponentInputSchema())),
+    getEvent: v.lazy(() => EventInputSchema())
+  })
+}
+
+export function EventArgumentInputSchema(): v.GenericSchema<EventArgumentInput> {
+  return v.object({
+    name: v.pipe(v.string(), v.minLength(5)),
+    value: v.pipe(v.string(), v.regex(/^foo/, "message"))
+  })
+}
+
+export function EventInputSchema(): v.GenericSchema<EventInput> {
+  return v.object({
+    arguments: v.array(v.lazy(() => EventArgumentInputSchema())),
+    options: v.nullish(v.array(EventOptionTypeSchema))
+  })
+}
+
+export function GuestSchema(): v.GenericSchema<Guest> {
+  return v.object({
+    __typename: v.optional(v.literal('Guest')),
+    lastLoggedIn: v.nullish(v.any())
+  })
+}
+
+export function HttpInputSchema(): v.GenericSchema<HttpInput> {
+  return v.object({
+    method: v.nullish(HttpMethodSchema),
+    url: v.any()
+  })
+}
+
+export function LayoutInputSchema(): v.GenericSchema<LayoutInput> {
+  return v.object({
+    dropdown: v.lazy(() => v.nullish(DropDownComponentInputSchema()))
+  })
+}
+
+export function MyTypeSchema(): v.GenericSchema<MyType> {
+  return v.object({
+    __typename: v.optional(v.literal('MyType')),
+    foo: v.nullish(v.string())
+  })
+}
+
+export function MyTypeFooArgsSchema(): v.GenericSchema<MyTypeFooArgs> {
+  return v.object({
+    a: v.nullish(v.string()),
+    b: v.number(),
+    c: v.nullish(v.boolean()),
+    d: v.number()
+  })
+}
+
+export function NamerSchema(): v.GenericSchema<Namer> {
+  return v.object({
+    name: v.nullish(v.string())
+  })
+}
+
+export function PageInputSchema(): v.GenericSchema<PageInput> {
+  return v.object({
+    attributes: v.nullish(v.array(v.lazy(() => AttributeInputSchema()))),
+    date: v.nullish(v.any()),
+    height: v.number(),
+    id: v.string(),
+    layout: v.lazy(() => LayoutInputSchema()),
+    pageType: PageTypeSchema,
+    postIDs: v.nullish(v.array(v.string())),
+    show: v.boolean(),
+    tags: v.nullish(v.array(v.nullable(v.string()))),
+    title: v.string(),
+    width: v.number()
+  })
+}
+
+export function UserSchema(): v.GenericSchema<User> {
+  return v.object({
+    __typename: v.optional(v.literal('User')),
+    createdAt: v.nullish(v.any()),
+    email: v.nullish(v.string()),
+    id: v.nullish(v.string()),
+    kind: v.nullish(UserKindSchema()),
+    name: v.nullish(v.string()),
+    password: v.nullish(v.string()),
+    updatedAt: v.nullish(v.any())
+  })
+}
+
+export function UserKindSchema() {
+  return v.union([AdminSchema(), GuestSchema()])
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "type-check:yup": "tsc --strict --skipLibCheck --noEmit example/yup/schemas.ts",
     "type-check:zod": "tsc --strict --skipLibCheck --noEmit example/zod/schemas.ts",
     "type-check:myzod": "tsc --strict --skipLibCheck --noEmit example/myzod/schemas.ts",
+    "type-check:valibot": "tsc --strict --skipLibCheck --noEmit example/valibot/schemas.ts",
     "test": "vitest run",
     "build": "run-p build:*",
     "build:main": "tsc -p tsconfig.main.json",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ts-dedent": "^2.2.0",
     "ts-jest": "29.1.4",
     "typescript": "5.4.5",
+    "valibot": "0.31.0-rc.6",
     "vitest": "^1.0.0",
     "yup": "1.4.0",
     "zod": "3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+      valibot:
+        specifier: 0.31.0-rc.6
+        version: 0.31.0-rc.6
       vitest:
         specifier: ^1.0.0
         version: 1.6.0(@types/node@20.12.12)
@@ -3697,6 +3700,9 @@ packages:
   v8-to-istanbul@9.0.1:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
     engines: {node: '>=10.12.0'}
+
+  valibot@0.31.0-rc.6:
+    resolution: {integrity: sha512-NW4mnZsSyLCj2TweTPBuo7jzhZywh3C2M0T5UU53po2jhg/0k7B63pQTt3hkcdZl2JkSZEYHliKzO/2OsLFqlQ==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -8350,6 +8356,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.18
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
+
+  valibot@0.31.0-rc.6: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import type { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 
-export type ValidationSchema = 'yup' | 'zod' | 'myzod';
+export type ValidationSchema = 'yup' | 'zod' | 'myzod' | 'valibot';
 export type ValidationSchemaExportType = 'function' | 'const';
 
 export interface DirectiveConfig {

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -115,7 +115,7 @@ export function buildApi(config: FormattedDirectiveConfig, directives: ReadonlyA
     .map((directive) => {
       const directiveName = directive.name.value;
       const argsConfig = config[directiveName];
-      return buildApiFromDirectiveArguments(argsConfig, directive.arguments ?? []).join('');
+      return buildApiFromDirectiveArguments(argsConfig, directive.arguments ?? []);
     })
     .join('')
 }
@@ -148,7 +148,7 @@ export function buildApiForValibot(config: FormattedDirectiveConfig, directives:
     .map((directive) => {
       const directiveName = directive.name.value;
       const argsConfig = config[directiveName];
-      const apis = buildApiFromDirectiveArguments(argsConfig, directive.arguments ?? []);
+      const apis = _buildApiFromDirectiveArguments(argsConfig, directive.arguments ?? []);
       return apis.map(api => `v${api}`);
     }).flat()
 }
@@ -165,7 +165,11 @@ function buildApiSchema(validationSchema: string[] | undefined, argValue: ConstV
   return `.${schemaApi}(${schemaApiArgs.join(', ')})`;
 }
 
-function buildApiFromDirectiveArguments(config: FormattedDirectiveArguments, args: ReadonlyArray<ConstArgumentNode>): string[] {
+function buildApiFromDirectiveArguments(config: FormattedDirectiveArguments, args: ReadonlyArray<ConstArgumentNode>): string {
+  return _buildApiFromDirectiveArguments(config, args).join('');
+}
+
+function _buildApiFromDirectiveArguments(config: FormattedDirectiveArguments, args: ReadonlyArray<ConstArgumentNode>): string[] {
   return args
     .map((arg) => {
       const argName = arg.name.value;

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -115,7 +115,7 @@ export function buildApi(config: FormattedDirectiveConfig, directives: ReadonlyA
     .map((directive) => {
       const directiveName = directive.name.value;
       const argsConfig = config[directiveName];
-      return buildApiFromDirectiveArguments(argsConfig, directive.arguments ?? []);
+      return buildApiFromDirectiveArguments(argsConfig, directive.arguments ?? []).join('');
     })
     .join('')
 }
@@ -132,7 +132,7 @@ function buildApiSchema(validationSchema: string[] | undefined, argValue: ConstV
   return `.${schemaApi}(${schemaApiArgs.join(', ')})`;
 }
 
-function buildApiFromDirectiveArguments(config: FormattedDirectiveArguments, args: ReadonlyArray<ConstArgumentNode>): string {
+function buildApiFromDirectiveArguments(config: FormattedDirectiveArguments, args: ReadonlyArray<ConstArgumentNode>): string[] {
   return args
     .map((arg) => {
       const argName = arg.name.value;
@@ -142,7 +142,6 @@ function buildApiFromDirectiveArguments(config: FormattedDirectiveArguments, arg
 
       return buildApiSchema(validationSchema, arg.value);
     })
-    .join('');
 }
 
 function buildApiFromDirectiveObjectArguments(config: FormattedDirectiveObjectArguments, argValue: ConstValueNode): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { MyZodSchemaVisitor } from './myzod/index';
 import type { SchemaVisitor } from './types';
 import { YupSchemaVisitor } from './yup/index';
 import { ZodSchemaVisitor } from './zod/index';
+import { ValibotSchemaVisitor } from './valibot';
 
 export const plugin: PluginFunction<ValidationSchemaPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
@@ -33,6 +34,8 @@ function schemaVisitor(schema: GraphQLSchema, config: ValidationSchemaPluginConf
     return new ZodSchemaVisitor(schema, config);
   else if (config?.schema === 'myzod')
     return new MyZodSchemaVisitor(schema, config);
+  else if (config?.schema === 'valibot')
+    return new ValibotSchemaVisitor(schema, config);
 
   return new YupSchemaVisitor(schema, config);
 }

--- a/src/valibot/index.ts
+++ b/src/valibot/index.ts
@@ -73,6 +73,8 @@ function generateFieldTypeValibotSchema(config: ValidationSchemaPluginConfig, vi
 
     if (isNonNullType(parentType))
       return gen;
+
+    return `v.nullish(${gen})`;
   }
   console.warn('unhandled type:', type);
   return '';

--- a/src/valibot/index.ts
+++ b/src/valibot/index.ts
@@ -12,6 +12,7 @@ import type { ValidationSchemaPluginConfig } from '../config';
 import { BaseSchemaVisitor } from '../schema_visitor';
 import type { Visitor } from '../visitor';
 import {
+  isInput,
   isListType,
   isNamedType,
   isNonNullType,
@@ -95,6 +96,12 @@ function generateNameNodeValibotSchema(config: ValidationSchemaPluginConfig, vis
   const converter = visitor.getNameNodeConverter(node);
 
   switch (converter?.targetKind) {
+    case 'InputObjectTypeDefinition':
+      // using switch-case rather than if-else to allow for future expansion
+      switch (config.validationSchemaExportType) {
+        default:
+          return `${converter.convertName()}Schema()`;
+      }
     default:
       if (converter?.targetKind)
         console.warn('Unknown targetKind', converter?.targetKind);
@@ -104,6 +111,9 @@ function generateNameNodeValibotSchema(config: ValidationSchemaPluginConfig, vis
 }
 
 function maybeLazy(type: TypeNode, schema: string): string {
+  if (isNamedType(type) && isInput(type.name.value))
+    return `v.lazy(() => ${schema})`;
+
   return schema;
 }
 

--- a/src/valibot/index.ts
+++ b/src/valibot/index.ts
@@ -56,11 +56,18 @@ export class ValibotSchemaVisitor extends BaseSchemaVisitor {
 
         // hoist enum declarations
         this.enumDeclarations.push(
-          new DeclarationBlock({})
-            .export()
-            .asKind('const')
-            .withName(`${enumname}Schema`)
-            .withContent(`v.enum_(${enumname})`).string,
+          this.config.enumsAsTypes
+            ? new DeclarationBlock({})
+              .export()
+              .asKind('const')
+              .withName(`${enumname}Schema`)
+              .withContent(`v.picklist([${node.values?.map(enumOption => `'${enumOption.name.value}'`).join(', ')}])`)
+              .string
+            : new DeclarationBlock({})
+              .export()
+              .asKind('const')
+              .withName(`${enumname}Schema`)
+              .withContent(`v.enum_(${enumname})`).string,
         );
       },
     };

--- a/src/valibot/index.ts
+++ b/src/valibot/index.ts
@@ -1,0 +1,109 @@
+import { DeclarationBlock, indent } from '@graphql-codegen/visitor-plugin-common';
+import type {
+  FieldDefinitionNode,
+  GraphQLSchema,
+  InputObjectTypeDefinitionNode,
+  InputValueDefinitionNode,
+  NameNode,
+  TypeNode,
+} from 'graphql';
+
+import type { ValidationSchemaPluginConfig } from '../config';
+import { BaseSchemaVisitor } from '../schema_visitor';
+import type { Visitor } from '../visitor';
+import {
+  isNamedType,
+  isNonNullType,
+} from './../graphql';
+
+export class ValibotSchemaVisitor extends BaseSchemaVisitor {
+  constructor(schema: GraphQLSchema, config: ValidationSchemaPluginConfig) {
+    super(schema, config);
+  }
+
+  importValidationSchema(): string {
+    return `import * as v from 'valibot'`;
+  }
+
+  initialEmit(): string {
+    return '';
+  }
+
+  get InputObjectTypeDefinition() {
+    return {
+      leave: (node: InputObjectTypeDefinitionNode) => {
+        const visitor = this.createVisitor('input');
+        const name = visitor.convertName(node.name.value);
+        this.importTypes.push(name);
+        return this.buildInputFields(node.fields ?? [], visitor, name);
+      },
+    };
+  }
+
+  protected buildInputFields(
+    fields: readonly (FieldDefinitionNode | InputValueDefinitionNode)[],
+    visitor: Visitor,
+    name: string,
+  ) {
+    const shape = fields.map(field => generateFieldValibotSchema(this.config, visitor, field, 2)).join(',\n');
+
+    switch (this.config.validationSchemaExportType) {
+      default:
+        return new DeclarationBlock({})
+          .export()
+          .asKind('function')
+          .withName(`${name}Schema(): v.GenericSchema<${name}>`)
+          .withBlock([indent(`return v.object({`), shape, indent('})')].join('\n')).string;
+    }
+  }
+}
+
+function generateFieldValibotSchema(config: ValidationSchemaPluginConfig, visitor: Visitor, field: InputValueDefinitionNode | FieldDefinitionNode, indentCount: number): string {
+  const gen = generateFieldTypeValibotSchema(config, visitor, field, field.type);
+  return indent(`${field.name.value}: ${maybeLazy(field.type, gen)}`, indentCount);
+}
+
+function generateFieldTypeValibotSchema(config: ValidationSchemaPluginConfig, visitor: Visitor, field: InputValueDefinitionNode | FieldDefinitionNode, type: TypeNode, parentType?: TypeNode): string {
+  if (isNonNullType(type)) {
+    const gen = generateFieldTypeValibotSchema(config, visitor, field, type.type, type);
+    return maybeLazy(type.type, gen);
+  }
+  if (isNamedType(type)) {
+    const gen = generateNameNodeValibotSchema(config, visitor, type.name);
+
+    if (isNonNullType(parentType))
+      return gen;
+  }
+  console.warn('unhandled type:', type);
+  return '';
+}
+
+function generateNameNodeValibotSchema(config: ValidationSchemaPluginConfig, visitor: Visitor, node: NameNode): string {
+  const converter = visitor.getNameNodeConverter(node);
+
+  switch (converter?.targetKind) {
+    default:
+      if (converter?.targetKind)
+        console.warn('Unknown targetKind', converter?.targetKind);
+
+      return valibot4Scalar(config, visitor, node.value);
+  }
+}
+
+function maybeLazy(type: TypeNode, schema: string): string {
+  return schema;
+}
+
+function valibot4Scalar(config: ValidationSchemaPluginConfig, visitor: Visitor, scalarName: string): string {
+  const tsType = visitor.getScalarType(scalarName);
+  switch (tsType) {
+    case 'string':
+      return `v.string()`;
+    case 'number':
+      return `v.number()`;
+    case 'boolean':
+      return `v.boolean()`;
+  }
+  console.warn('unhandled scalar name:', scalarName);
+  return 'v.any()';
+}

--- a/src/valibot/index.ts
+++ b/src/valibot/index.ts
@@ -151,6 +151,9 @@ function maybeLazy(type: TypeNode, schema: string): string {
 }
 
 function valibot4Scalar(config: ValidationSchemaPluginConfig, visitor: Visitor, scalarName: string): string {
+  if (config.scalarSchemas?.[scalarName])
+    return config.scalarSchemas[scalarName];
+
   const tsType = visitor.getScalarType(scalarName);
   switch (tsType) {
     case 'string':

--- a/tests/directive.spec.ts
+++ b/tests/directive.spec.ts
@@ -352,7 +352,7 @@ describe('format directive config', () => {
         config: FormattedDirectiveArguments
         args: ReadonlyArray<ConstArgumentNode>
       }
-      want: string
+      want: string[]
     }[] = [
       {
         name: 'string',
@@ -364,7 +364,7 @@ describe('format directive config', () => {
             msg: `"hello"`,
           }),
         },
-        want: `.required("hello")`,
+        want: [`.required("hello")`],
       },
       {
         name: 'string with additional stuff',
@@ -376,7 +376,7 @@ describe('format directive config', () => {
             startWith: `"hello"`,
           }),
         },
-        want: `.matched("^hello")`,
+        want: [`.matched("^hello")`],
       },
       {
         name: 'number',
@@ -388,7 +388,7 @@ describe('format directive config', () => {
             minLength: `1`,
           }),
         },
-        want: `.min(1)`,
+        want: [`.min(1)`],
       },
       {
         name: 'boolean',
@@ -401,7 +401,7 @@ describe('format directive config', () => {
             enabled: `true`,
           }),
         },
-        want: `.strict(true)`,
+        want: [`.strict(true)`],
       },
       {
         name: 'list',
@@ -413,7 +413,7 @@ describe('format directive config', () => {
             minLength: `[1, "message"]`,
           }),
         },
-        want: `.min(1, "message")`,
+        want: [`.min(1, "message")`],
       },
       {
         name: 'object in list',
@@ -425,7 +425,7 @@ describe('format directive config', () => {
             matches: `["hello", {message:"message", excludeEmptyString:true}]`,
           }),
         },
-        want: `.matches("hello", {"message":"message","excludeEmptyString":true})`,
+        want: [`.matches("hello", {"message":"message","excludeEmptyString":true})`],
       },
       {
         name: 'two arguments but matched to first argument',
@@ -438,7 +438,7 @@ describe('format directive config', () => {
             msg2: `"world"`,
           }),
         },
-        want: `.required("hello")`,
+        want: [`.required("hello")`, ``],
       },
       {
         name: 'two arguments but matched to second argument',
@@ -451,7 +451,7 @@ describe('format directive config', () => {
             msg2: `"world"`,
           }),
         },
-        want: `.required("world")`,
+        want: [``, `.required("world")`],
       },
       {
         name: 'two arguments matched all',
@@ -465,7 +465,7 @@ describe('format directive config', () => {
             minLength: `1`,
           }),
         },
-        want: `.required("message").min(1)`,
+        want: [`.required("message")`, `.min(1)`],
       },
       {
         name: 'argument matches validation schema api',
@@ -479,7 +479,7 @@ describe('format directive config', () => {
             format: `"uri"`,
           }),
         },
-        want: `.url()`,
+        want: [`.url()`],
       },
       {
         name: 'argument matched argument but doesn\'t match api',
@@ -493,7 +493,7 @@ describe('format directive config', () => {
             format: `"uuid"`,
           }),
         },
-        want: ``,
+        want: [``],
       },
       {
         name: 'complex',
@@ -509,7 +509,7 @@ describe('format directive config', () => {
             format: `"uri"`,
           }),
         },
-        want: `.required("message").url()`,
+        want: [`.required("message")`, `.url()`],
       },
       {
         name: 'complex 2',
@@ -525,7 +525,7 @@ describe('format directive config', () => {
             format: `"uuid"`,
           }),
         },
-        want: `.required("message")`,
+        want: [`.required("message")`, ``],
       },
     ];
     for (const tc of cases) {

--- a/tests/directive.spec.ts
+++ b/tests/directive.spec.ts
@@ -9,6 +9,7 @@ import type {
 } from '../src/directive';
 import {
   buildApi,
+  buildApiForValibot,
   exportedForTesting,
   formatDirectiveConfig,
   formatDirectiveObjectArguments,
@@ -599,6 +600,66 @@ describe('format directive config', () => {
       it(tc.name, () => {
         const { config, args } = tc.args;
         const got = buildApi(config, args);
+        expect(got).toStrictEqual(tc.want);
+      });
+    }
+  });
+
+  describe('buildApiForValibot', () => {
+    const cases: {
+      name: string
+      args: {
+        config: FormattedDirectiveConfig
+        args: ReadonlyArray<ConstDirectiveNode>
+      }
+      want: string[]
+    }[] = [
+      {
+        name: 'valid',
+        args: {
+          config: {
+            constraint: {
+              minLength: ['minLength', '$1'],
+              format: {
+                uri: ['url'],
+                email: ['email'],
+              },
+            },
+          },
+          args: [
+            // @constraint(minLength: 100, format: "email")
+            buildConstDirectiveNodes('constraint', {
+              minLength: `100`,
+              format: `"email"`,
+            }),
+          ],
+        },
+        want: [`v.minLength(100)`, `v.email()`],
+      },
+      {
+        name: 'enum',
+        args: {
+          config: {
+            constraint: {
+              format: {
+                URI: ['uri'],
+              },
+            },
+          },
+          args: [
+            // @constraint(format: EMAIL)
+            buildConstDirectiveNodes('constraint', {
+              format: 'URI',
+            }),
+          ],
+        },
+        want: [`v.uri()`],
+      },
+    ];
+    for (const tc of cases) {
+      it(tc.name, () => {
+        const { config, args } = tc.args;
+        const got = buildApiForValibot(config, args);
         expect(got).toStrictEqual(tc.want);
       });
     }

--- a/tests/directive.spec.ts
+++ b/tests/directive.spec.ts
@@ -353,7 +353,7 @@ describe('format directive config', () => {
         config: FormattedDirectiveArguments
         args: ReadonlyArray<ConstArgumentNode>
       }
-      want: string[]
+      want: string
     }[] = [
       {
         name: 'string',
@@ -365,7 +365,7 @@ describe('format directive config', () => {
             msg: `"hello"`,
           }),
         },
-        want: [`.required("hello")`],
+        want: `.required("hello")`,
       },
       {
         name: 'string with additional stuff',
@@ -377,7 +377,7 @@ describe('format directive config', () => {
             startWith: `"hello"`,
           }),
         },
-        want: [`.matched("^hello")`],
+        want: `.matched("^hello")`,
       },
       {
         name: 'number',
@@ -389,7 +389,7 @@ describe('format directive config', () => {
             minLength: `1`,
           }),
         },
-        want: [`.min(1)`],
+        want: `.min(1)`,
       },
       {
         name: 'boolean',
@@ -402,7 +402,7 @@ describe('format directive config', () => {
             enabled: `true`,
           }),
         },
-        want: [`.strict(true)`],
+        want: `.strict(true)`,
       },
       {
         name: 'list',
@@ -414,7 +414,7 @@ describe('format directive config', () => {
             minLength: `[1, "message"]`,
           }),
         },
-        want: [`.min(1, "message")`],
+        want: `.min(1, "message")`,
       },
       {
         name: 'object in list',
@@ -426,7 +426,7 @@ describe('format directive config', () => {
             matches: `["hello", {message:"message", excludeEmptyString:true}]`,
           }),
         },
-        want: [`.matches("hello", {"message":"message","excludeEmptyString":true})`],
+        want: `.matches("hello", {"message":"message","excludeEmptyString":true})`,
       },
       {
         name: 'two arguments but matched to first argument',
@@ -439,7 +439,7 @@ describe('format directive config', () => {
             msg2: `"world"`,
           }),
         },
-        want: [`.required("hello")`, ``],
+        want: `.required("hello")`,
       },
       {
         name: 'two arguments but matched to second argument',
@@ -452,7 +452,7 @@ describe('format directive config', () => {
             msg2: `"world"`,
           }),
         },
-        want: [``, `.required("world")`],
+        want: `.required("world")`,
       },
       {
         name: 'two arguments matched all',
@@ -466,7 +466,7 @@ describe('format directive config', () => {
             minLength: `1`,
           }),
         },
-        want: [`.required("message")`, `.min(1)`],
+        want: `.required("message").min(1)`,
       },
       {
         name: 'argument matches validation schema api',
@@ -480,7 +480,7 @@ describe('format directive config', () => {
             format: `"uri"`,
           }),
         },
-        want: [`.url()`],
+        want: `.url()`,
       },
       {
         name: 'argument matched argument but doesn\'t match api',
@@ -494,7 +494,7 @@ describe('format directive config', () => {
             format: `"uuid"`,
           }),
         },
-        want: [``],
+        want: ``,
       },
       {
         name: 'complex',
@@ -510,7 +510,7 @@ describe('format directive config', () => {
             format: `"uri"`,
           }),
         },
-        want: [`.required("message")`, `.url()`],
+        want: `.required("message").url()`,
       },
       {
         name: 'complex 2',
@@ -526,7 +526,7 @@ describe('format directive config', () => {
             format: `"uuid"`,
           }),
         },
-        want: [`.required("message")`, ``],
+        want: `.required("message")`,
       },
     ];
     for (const tc of cases) {

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -214,4 +214,36 @@ describe('valibot', () => {
       "
     `);
   });
+  it('with importFrom', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input Say {
+        phrase: String!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'valibot',
+        importFrom: './types',
+      },
+      {},
+    );
+    expect(result.prepend).toMatchInlineSnapshot(`
+      [
+        "import * as v from 'valibot'",
+        "import { Say } from './types'",
+      ]
+    `);
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+
+      export function SaySchema(): v.GenericSchema<Say> {
+        return v.object({
+          phrase: v.string()
+        })
+      }
+      "
+    `);
+  });
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -89,4 +89,40 @@ describe('valibot', () => {
       "
     `);
   })
+  it('ref input object', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input AInput {
+        b: BInput!
+      }
+      input BInput {
+        c: CInput!
+      }
+      input CInput {
+        a: AInput!
+      }
+    `);
+    const scalars = undefined
+    const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+      export function AInputSchema(): v.GenericSchema<AInput> {
+        return v.object({
+          b: v.lazy(() => BInputSchema())
+        })
+      }
+
+      export function BInputSchema(): v.GenericSchema<BInput> {
+        return v.object({
+          c: v.lazy(() => CInputSchema())
+        })
+      }
+
+      export function CInputSchema(): v.GenericSchema<CInput> {
+        return v.object({
+          a: v.lazy(() => AInputSchema())
+        })
+      }
+      "
+    `);
+  })
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -301,4 +301,41 @@ describe('valibot', () => {
       "
     `);
   });
+  it.todo('with notAllowEmptyString')
+  it.todo('with notAllowEmptyString issue #386')
+  it('with scalarSchemas', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input ScalarsInput {
+        date: Date!
+        email: Email
+        str: String!
+      }
+      scalar Date
+      scalar Email
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'valibot',
+        scalarSchemas: {
+          Date: 'v.date()',
+          Email: 'v.string([v.email()])',
+        },
+      },
+      {},
+    );
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+
+      export function ScalarsInputSchema(): v.GenericSchema<ScalarsInput> {
+        return v.object({
+          date: v.date(),
+          email: v.nullish(v.string([v.email()])),
+          str: v.string()
+        })
+      }
+      "
+    `)
+  });
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -61,4 +61,32 @@ describe('valibot', () => {
       "
     `);
   })
+  it('array', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input PrimitiveInput {
+        a: [String]
+        b: [String!]
+        c: [String!]!
+        d: [[String]]
+        e: [[String]!]
+        f: [[String]!]!
+      }
+    `);
+    const scalars = undefined
+    const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+      export function PrimitiveInputSchema(): v.GenericSchema<PrimitiveInput> {
+        return v.object({
+          a: v.nullish(v.array(v.nullable(v.string()))),
+          b: v.nullish(v.array(v.string())),
+          c: v.array(v.string()),
+          d: v.nullish(v.array(v.nullish(v.array(v.nullable(v.string()))))),
+          e: v.nullish(v.array(v.array(v.nullable(v.string())))),
+          f: v.array(v.array(v.nullable(v.string())))
+        })
+      }
+      "
+    `);
+  })
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -338,4 +338,75 @@ describe('valibot', () => {
       "
     `)
   });
+  it.todo('with typesPrefix')
+  it.todo('with typesSuffix')
+  it.todo('with default input values')
+  describe('issues #19', () => {
+    it('string field', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        input UserCreateInput {
+          profile: String @constraint(minLength: 1, maxLength: 5000)
+        }
+        directive @constraint(minLength: Int!, maxLength: Int!) on INPUT_FIELD_DEFINITION
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'valibot',
+          directives: {
+            constraint: {
+              minLength: ['minLength', '$1', 'Please input more than $1'],
+              maxLength: ['maxLength', '$1', 'Please input less than $1'],
+            },
+          },
+        },
+        {},
+      );
+      expect(result.content).toMatchInlineSnapshot(`
+        "
+
+        export function UserCreateInputSchema(): v.GenericSchema<UserCreateInput> {
+          return v.object({
+            profile: v.nullish(v.pipe(v.string(), v.minLength(1, "Please input more than 1"), v.maxLength(5000, "Please input less than 5000")))
+          })
+        }
+        "
+      `)
+    });
+
+    it('not null field', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        input UserCreateInput {
+          profile: String! @constraint(minLength: 1, maxLength: 5000)
+        }
+        directive @constraint(minLength: Int!, maxLength: Int!) on INPUT_FIELD_DEFINITION
+      `);
+      const result = await plugin(
+        schema,
+        [],
+        {
+          schema: 'valibot',
+          directives: {
+            constraint: {
+              minLength: ['minLength', '$1', 'Please input more than $1'],
+              maxLength: ['maxLength', '$1', 'Please input less than $1'],
+            },
+          },
+        },
+        {},
+      );
+
+      expect(result.content).toMatchInlineSnapshot(`
+        "
+
+        export function UserCreateInputSchema(): v.GenericSchema<UserCreateInput> {
+          return v.object({
+            profile: v.pipe(v.string(), v.minLength(1, "Please input more than 1"), v.maxLength(5000, "Please input less than 5000"))
+          })
+        }
+        "
+      `)
+    });
+  })
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -246,4 +246,37 @@ describe('valibot', () => {
       "
     `);
   });
+  it('with importFrom & useTypeImports', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input Say {
+        phrase: String!
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'valibot',
+        importFrom: './types',
+        useTypeImports: true,
+      },
+      {},
+    );
+    expect(result.prepend).toMatchInlineSnapshot(`
+      [
+        "import * as v from 'valibot'",
+        "import type { Say } from './types'",
+      ]
+    `);
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+
+      export function SaySchema(): v.GenericSchema<Say> {
+        return v.object({
+          phrase: v.string()
+        })
+      }
+      "
+    `);
+  });
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -181,4 +181,37 @@ describe('valibot', () => {
       "
     `);
   })
+  it('with scalars', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input Say {
+        phrase: Text!
+        times: Count!
+      }
+      scalar Count
+      scalar Text
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'valibot',
+        scalars: {
+          Text: 'string',
+          Count: 'number',
+        },
+      },
+      {},
+    );
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+
+      export function SaySchema(): v.GenericSchema<Say> {
+        return v.object({
+          phrase: v.string(),
+          times: v.number()
+        })
+      }
+      "
+    `);
+  });
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -19,6 +19,7 @@ describe('valibot', () => {
     const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
     expect(result.content).toMatchInlineSnapshot(`
       "
+
       export function PrimitiveInputSchema(): v.GenericSchema<PrimitiveInput> {
         return v.object({
           a: v.string(),
@@ -48,6 +49,7 @@ describe('valibot', () => {
     const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
     expect(result.content).toMatchInlineSnapshot(`
       "
+
       export function PrimitiveInputSchema(): v.GenericSchema<PrimitiveInput> {
         return v.object({
           a: v.nullish(v.string()),
@@ -76,6 +78,7 @@ describe('valibot', () => {
     const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
     expect(result.content).toMatchInlineSnapshot(`
       "
+
       export function PrimitiveInputSchema(): v.GenericSchema<PrimitiveInput> {
         return v.object({
           a: v.nullish(v.array(v.nullable(v.string()))),
@@ -105,6 +108,7 @@ describe('valibot', () => {
     const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
     expect(result.content).toMatchInlineSnapshot(`
       "
+
       export function AInputSchema(): v.GenericSchema<AInput> {
         return v.object({
           b: v.lazy(() => BInputSchema())
@@ -120,6 +124,31 @@ describe('valibot', () => {
       export function CInputSchema(): v.GenericSchema<CInput> {
         return v.object({
           a: v.lazy(() => AInputSchema())
+        })
+      }
+      "
+    `);
+  })
+  it.todo('nested input object')
+  it('enum', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      enum PageType {
+        PUBLIC
+        BASIC_AUTH
+      }
+      input PageInput {
+        pageType: PageType!
+      }
+    `);
+    const scalars = undefined
+    const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+      export const PageTypeSchema = v.enum_(PageType);
+
+      export function PageInputSchema(): v.GenericSchema<PageInput> {
+        return v.object({
+          pageType: PageTypeSchema
         })
       }
       "

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -154,4 +154,31 @@ describe('valibot', () => {
       "
     `);
   })
+  it('camelcase', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input HTTPInput {
+        method: HTTPMethod
+        url: URL!
+      }
+      enum HTTPMethod {
+        GET
+        POST
+      }
+      scalar URL # unknown scalar, should be any
+    `);
+    const scalars = undefined
+    const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+      export const HttpMethodSchema = v.enum_(HttpMethod);
+
+      export function HttpInputSchema(): v.GenericSchema<HttpInput> {
+        return v.object({
+          method: v.nullish(HttpMethodSchema),
+          url: v.any()
+        })
+      }
+      "
+    `);
+  })
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -1,0 +1,34 @@
+import { buildSchema } from 'graphql';
+
+import { plugin } from '../src/index';
+
+describe('valibot', () => {
+  it('non-null and defined', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input PrimitiveInput {
+        a: ID!
+        b: String!
+        c: Boolean!
+        d: Int!
+        e: Float!
+      }
+    `);
+    const scalars = {
+      ID: 'string',
+    }
+    const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+      export function PrimitiveInputSchema(): v.GenericSchema<PrimitiveInput> {
+        return v.object({
+          a: v.string(),
+          b: v.string(),
+          c: v.boolean(),
+          d: v.number(),
+          e: v.number()
+        })
+      }
+      "
+    `);
+  })
+})

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -939,5 +939,4 @@ describe('valibot', () => {
   it.todo('exports as const instead of func')
   it.todo('generate both input & type, export as const')
   it.todo('issue #394')
-  it.todo('issue #394')
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -279,4 +279,26 @@ describe('valibot', () => {
       "
     `);
   });
+  it('with enumsAsTypes', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      enum PageType {
+        PUBLIC
+        BASIC_AUTH
+      }
+    `);
+    const result = await plugin(
+      schema,
+      [],
+      {
+        schema: 'valibot',
+        enumsAsTypes: true,
+      },
+      {},
+    );
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+      export const PageTypeSchema = v.picklist([\'PUBLIC\', \'BASIC_AUTH\']);
+      "
+    `);
+  });
 })

--- a/tests/valibot.spec.ts
+++ b/tests/valibot.spec.ts
@@ -31,4 +31,34 @@ describe('valibot', () => {
       "
     `);
   })
+  it('nullish', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input PrimitiveInput {
+        a: ID
+        b: String
+        c: Boolean
+        d: Int
+        e: Float
+        z: String! # no defined check
+      }
+    `);
+    const scalars = {
+      ID: 'string',
+    }
+    const result = await plugin(schema, [], { schema: 'valibot', scalars }, {});
+    expect(result.content).toMatchInlineSnapshot(`
+      "
+      export function PrimitiveInputSchema(): v.GenericSchema<PrimitiveInput> {
+        return v.object({
+          a: v.nullish(v.string()),
+          b: v.nullish(v.string()),
+          c: v.nullish(v.boolean()),
+          d: v.nullish(v.number()),
+          e: v.nullish(v.number()),
+          z: v.string()
+        })
+      }
+      "
+    `);
+  })
 })


### PR DESCRIPTION
- ref: https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/issues/577

This PR implements valibot support. 
First of all, only the contents of [example/zod/schemas.ts](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/blob/213f36fd0ec7f4762a6dd525789b6b29399d7118/example/zod/schemas.ts) are supported, not all configurations. Even at this point, the use case for my project can be met, and I plan to begin production operation when it is released.

Should documentation still be added in its current condition? I would like to discuss this.
After merging this PR, I will implement the test which is a todo.