### PR TITLE
fixed graphql-codegen-esm Cannot use import statement outside a module

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -9,7 +9,7 @@ generates:
         ID: string
   example/yup/schemas.ts:
     plugins:
-      - ./dist/main/index.js:
+      - ./dist/cjs/index.js:
           schema: yup
           importFrom: ../types
           withObjectType: true
@@ -45,7 +45,7 @@ generates:
             ID: string
   example/zod/schemas.ts:
     plugins:
-      - ./dist/main/index.js:
+      - ./dist/cjs/index.js:
           schema: zod
           importFrom: ../types
           withObjectType: true
@@ -68,7 +68,7 @@ generates:
             ID: string
   example/myzod/schemas.ts:
     plugins:
-      - ./dist/main/index.js:
+      - ./dist/cjs/index.js:
           schema: myzod
           importFrom: ../types
           withObjectType: true
@@ -83,7 +83,7 @@ generates:
             ID: string
   example/valibot/schemas.ts:
     plugins:
-      - ./dist/main/index.js:
+      - ./dist/cjs/index.js:
           schema: valibot
           importFrom: ../types
           withObjectType: true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "graphql-codegen-typescript-validation-schema",
+  "type": "module",
   "version": "0.15.0",
   "packageManager": "pnpm@9.4.0",
   "description": "GraphQL Code Generator plugin to generate form validation schema from your GraphQL schema",
@@ -28,14 +29,27 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/module/index.js",
-      "require": "./dist/main/index.js"
-    }
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      },
+      "default": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./package.json": "./package.json"
   },
-  "main": "dist/main/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
-  "module": "dist/module/index.js",
+  "typescript": {
+    "definition": "dist/types/index.d.ts"
+  },
   "files": [
     "!dist/**/*.tsbuildinfo",
     "LICENSE",
@@ -50,12 +64,13 @@
     "type-check:valibot": "tsc --strict --skipLibCheck --noEmit example/valibot/schemas.ts",
     "test": "vitest run",
     "build": "run-p build:*",
-    "build:main": "tsc -p tsconfig.main.json",
-    "build:module": "tsc -p tsconfig.module.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "build:esm": "tsc -p tsconfig.esm.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "generate": "run-p build:* && graphql-codegen",
+    "generate:esm": "run-p build:* && graphql-codegen-esm",
     "prepublish": "run-p build:*"
   },
   "peerDependencies": {

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -1,8 +1,8 @@
 import type { ConstArgumentNode, ConstDirectiveNode, ConstValueNode } from 'graphql';
 import { Kind, valueFromASTUntyped } from 'graphql';
 
-import type { DirectiveConfig, DirectiveObjectArguments } from './config';
-import { isConvertableRegexp } from './regexp';
+import type { DirectiveConfig, DirectiveObjectArguments } from './config.js';
+import { isConvertableRegexp } from './regexp.js';
 
 export interface FormattedDirectiveConfig {
   [directive: string]: FormattedDirectiveArguments

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,3 +59,5 @@ function _transformSchemaAST(schema: GraphQLSchema, config: ValidationSchemaPlug
     ast,
   };
 }
+
+export type { ValidationSchemaPluginConfig }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,13 @@ import { transformSchemaAST } from '@graphql-codegen/schema-ast';
 import type { GraphQLSchema } from 'graphql';
 import { buildSchema, printSchema, visit } from 'graphql';
 
-import type { ValidationSchemaPluginConfig } from './config';
-import { isGeneratedByIntrospection, topologicalSortAST } from './graphql';
-import { MyZodSchemaVisitor } from './myzod/index';
-import type { SchemaVisitor } from './types';
-import { YupSchemaVisitor } from './yup/index';
-import { ZodSchemaVisitor } from './zod/index';
-import { ValibotSchemaVisitor } from './valibot';
+import type { ValidationSchemaPluginConfig } from './config.js';
+import { isGeneratedByIntrospection, topologicalSortAST } from './graphql.js';
+import { MyZodSchemaVisitor } from './myzod/index.js';
+import type { SchemaVisitor } from './types.js';
+import { YupSchemaVisitor } from './yup/index.js';
+import { ZodSchemaVisitor } from './zod/index.js';
+import { ValibotSchemaVisitor } from './valibot/index.js';
 
 export const plugin: PluginFunction<ValidationSchemaPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,

--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -16,10 +16,10 @@ import {
 } from 'graphql';
 
 import { resolveExternalModuleAndFn } from '@graphql-codegen/plugin-helpers';
-import type { ValidationSchemaPluginConfig } from '../config';
-import { buildApi, formatDirectiveConfig } from '../directive';
-import { BaseSchemaVisitor } from '../schema_visitor';
-import type { Visitor } from '../visitor';
+import type { ValidationSchemaPluginConfig } from '../config.js';
+import { buildApi, formatDirectiveConfig } from '../directive.js';
+import { BaseSchemaVisitor } from '../schema_visitor.js';
+import type { Visitor } from '../visitor.js';
 import {
   InterfaceTypeDefinitionBuilder,
   ObjectTypeDefinitionBuilder,

--- a/src/schema_visitor.ts
+++ b/src/schema_visitor.ts
@@ -6,9 +6,9 @@ import type {
   ObjectTypeDefinitionNode,
 } from 'graphql';
 
-import type { ValidationSchemaPluginConfig } from './config';
-import type { SchemaVisitor } from './types';
-import { Visitor } from './visitor';
+import type { ValidationSchemaPluginConfig } from './config.js';
+import type { SchemaVisitor } from './types.js';
+import { Visitor } from './visitor.js';
 
 export abstract class BaseSchemaVisitor implements SchemaVisitor {
   protected importTypes: string[] = [];

--- a/src/valibot/index.ts
+++ b/src/valibot/index.ts
@@ -12,10 +12,10 @@ import type {
   UnionTypeDefinitionNode,
 } from 'graphql';
 
-import type { ValidationSchemaPluginConfig } from '../config';
-import { BaseSchemaVisitor } from '../schema_visitor';
-import type { Visitor } from '../visitor';
-import { buildApiForValibot, formatDirectiveConfig } from '../directive';
+import type { ValidationSchemaPluginConfig } from '../config.js';
+import { BaseSchemaVisitor } from '../schema_visitor.js';
+import type { Visitor } from '../visitor.js';
+import { buildApiForValibot, formatDirectiveConfig } from '../directive.js';
 import {
   InterfaceTypeDefinitionBuilder,
   ObjectTypeDefinitionBuilder,

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -10,7 +10,7 @@ import {
   specifiedScalarTypes,
 } from 'graphql';
 
-import type { ValidationSchemaPluginConfig } from './config';
+import type { ValidationSchemaPluginConfig } from './config.js';
 
 export class Visitor extends TsVisitor {
   constructor(

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -16,10 +16,10 @@ import {
 } from 'graphql';
 
 import { resolveExternalModuleAndFn } from '@graphql-codegen/plugin-helpers';
-import type { ValidationSchemaPluginConfig } from '../config';
-import { buildApi, formatDirectiveConfig } from '../directive';
-import { BaseSchemaVisitor } from '../schema_visitor';
-import type { Visitor } from '../visitor';
+import type { ValidationSchemaPluginConfig } from '../config.js';
+import { buildApi, formatDirectiveConfig } from '../directive.js';
+import { BaseSchemaVisitor } from '../schema_visitor.js';
+import type { Visitor } from '../visitor.js';
 import {
   InterfaceTypeDefinitionBuilder,
   ObjectTypeDefinitionBuilder,

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -16,10 +16,10 @@ import {
 } from 'graphql';
 
 import { resolveExternalModuleAndFn } from '@graphql-codegen/plugin-helpers';
-import type { ValidationSchemaPluginConfig } from '../config';
-import { buildApi, formatDirectiveConfig } from '../directive';
-import { BaseSchemaVisitor } from '../schema_visitor';
-import type { Visitor } from '../visitor';
+import type { ValidationSchemaPluginConfig } from '../config.js';
+import { buildApi, formatDirectiveConfig } from '../directive.js';
+import { BaseSchemaVisitor } from '../schema_visitor.js';
+import type { Visitor } from '../visitor.js';
 import {
   InterfaceTypeDefinitionBuilder,
   ObjectTypeDefinitionBuilder,

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "rootDir": "src",
     "types": ["node"],
     "declaration": false,
-    "outDir": "dist/main"
+    "outDir": "dist/cjs"
   },
   "exclude": [
     "example",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     "types": ["node"],
     "declaration": false,
-    "outDir": "dist/module"
+    "outDir": "dist/esm"
   },
   "exclude": [
     "node_modules/**",


### PR DESCRIPTION
Solve #623

This PR includes

- Renamed dist directory names
  - main -> cjs
  - module -> esm
- Changed type to `module` in package.json
- Fixed `Cannot use import statement outside a module` in graphql-codegen-esm
