### PR TITLE
Fix references to useEnumTypeAsDefault

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ type: `ValidationSchemaExportType` default: `'function'`
 
 Specify validation schema export type.
 
-### `useEnumTypeAsDefault`
+### `useEnumTypeAsDefaultValue`
 
 type: `boolean` default: `false`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,7 +223,7 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    *       - typescript
    *       - graphql-codegen-validation-schema
    *     config:
-   *       useEnumTypeAsDefault: true
+   *       useEnumTypeAsDefaultValue: true
    * ```
    */
   useEnumTypeAsDefaultValue?: boolean


### PR DESCRIPTION
In several places, including `README.md`, the config `useEnumTypeAsDefaultValue` is referred erroneously as `useEnumTypeAsDefault`. This silently fails and is quite confusing