### PR TITLE
fix: use the correct name of enum, if the field name and the enum name are different (yup).

### DIFF
--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -301,8 +301,8 @@ function shapeFields(fields: readonly (FieldDefinitionNode | InputValueDefinitio
 
             if (config.namingConvention?.enumValues)
               value = convertNameParts(defaultValue.value, resolveExternalModuleAndFn(config.namingConvention?.enumValues), config?.namingConvention?.transformUnderscore);
-
-            fieldSchema = `${fieldSchema}.default(${visitor.convertName(field.name.value)}.${value})`;
+            const enumName = field.type?.type?.name.value ?? field.name.value
+            fieldSchema = `${fieldSchema}.default(${visitor.convertName(enumName)}.${value})`;
           }
           else {
             fieldSchema = `${fieldSchema}.default("${escapeGraphQLCharacters(defaultValue.value)}")`;

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -1610,6 +1610,7 @@ describe('yup', () => {
       }
       input PageInput {
         pageType: PageType! = PUBLIC
+        customPageType: PageType! = PUBLIC
         greeting: String = "Hello"
         score: Int = 100
         ratio: Float = 0.5
@@ -1633,6 +1634,7 @@ describe('yup', () => {
     expect(result.content).toContain('export function PageInputSchema(): yup.ObjectSchema<PageInput>');
 
     expect(result.content).toContain('pageType: PageTypeSchema.nonNullable().default(PageType.Public)');
+    expect(result.content).toContain('customPageType: PageTypeSchema.nonNullable().default(PageType.Public)');
     expect(result.content).toContain('greeting: yup.string().defined().nullable().default("Hello").optional()');
     expect(result.content).toContain('score: yup.number().defined().nullable().default(100).optional()');
     expect(result.content).toContain('ratio: yup.number().defined().nullable().default(0.5).optional()');


### PR DESCRIPTION
hey, just check updates in `tests/yup.spec.ts` to figure out the problem.

If the field name and the enum name are different (e.g. `customPageName` and `PageName`), then plugin provides incorrect enum name for the default value in the scope of yup. It just does PascalCase of the field name, but doesn't use the exact enum name.

I checked implementations for zod and myzod and they use the type name, not the field name.