### PR TITLE
Added config opts: separateSchemaObject, inputDiscriminator, zodv4 schema, and lazyStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ type: `ValidationSchema` default: `'yup'`
 
 Specify generete validation schema you want.
 
-You can specify `yup` or `zod` or `myzod`.
+You can specify `yup` or `zod` or `zodv4` or `myzod`.
 
 ```yml
 generates:
@@ -85,6 +85,77 @@ Then the generator generates code with import statement like below.
 import { GeneratedInput } from './graphql'
 
 /* generates validation schema here */
+```
+
+### `inputDiscriminator`
+
+type: `string`
+
+When provided, adds a discriminator to the input schemas with a literal value of the input type name.
+
+```yml
+generates:
+  path/to/graphql.ts:
+    plugins:
+      - typescript
+  path/to/validation.ts:
+    plugins:
+      - typescript-validation-schema
+    config:
+      inputDiscriminator: __kind # discriminator key
+```
+
+### `lazyStrategy`
+
+type: `LazyStrategy` default: `'all'`
+
+Specify if lazy() => should be added all references or only circular references.
+
+You can specify `all` or `circular`.
+
+```yml
+generates:
+  path/to/graphql.ts:
+    plugins:
+      - typescript
+  path/to/validation.ts:
+    plugins:
+      - typescript-validation-schema
+    config:
+      lazyStrategy: circular
+```
+
+### `separateSchemaObject`
+
+type: `boolean` default `false`
+
+Will separate the schema object from the object definition when set to true.
+
+```yml
+generates:
+  path/to/graphql.ts:
+    plugins:
+      - typescript
+  path/to/validation.ts:
+    plugins:
+      - typescript-validation-schema
+    config:
+      schemaObjectSeparate: true
+```
+
+Then the generator generates code like below.
+
+```ts
+/* When set to false */
+// If validationSchemaExportType is 'const' and Zod as an example
+export const Schema: z.ZodObject<SchemaType> = z.object({foo: bar})
+
+
+/* When set to false */
+// If validationSchemaExportType is 'const' and Zod as an example
+// While these seem the same, Zod for example will add [x: string]: unknown to the first example while this will prevent that.
+export const schemaObject: SchemaType = {foo: bar}
+export const Schema = z.object(schemaObject)
 ```
 
 ### `schemaNamespacedImportName`
@@ -213,6 +284,16 @@ config:
   scalarSchemas:
     Date: z.date()
     Email: z.string().email()
+```
+
+#### zodv4 schema
+
+```yml
+config:
+  schema: zodv4
+  scalarSchemas:
+    Date: z.date()
+    Email: z.email()
 ```
 
 ### `defaultScalarTypeSchema`

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,9 @@
 import type { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
 import type { NamingConventionMap } from '@graphql-codegen/visitor-plugin-common';
 
-export type ValidationSchema = 'yup' | 'zod' | 'myzod' | 'valibot';
+export type ValidationSchema = 'yup' | 'zod' | 'zodv4' | 'myzod' | 'valibot';
 export type ValidationSchemaExportType = 'function' | 'const';
+export type LazyStrategy = 'all' | 'circular'
 
 export interface DirectiveConfig {
   [directive: string]: {
@@ -54,6 +55,59 @@ export interface ValidationSchemaPluginConfig extends TypeScriptPluginConfig {
    * ```
    */
   importFrom?: string
+  /**
+   * @description When provided, adds a discriminator to the input schemas with a literal value of the input type name.
+   * @default ""
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/types.ts:
+   *     plugins:
+   *       - typescript
+   *   path/to/schemas.ts:
+   *     plugins:
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       schema: yup
+   *       inputDiscriminator: __kind
+   * ```
+   */
+  inputDiscriminator?: string
+  /**
+   * @description Setting to determine when to set a property to lazy. 'Circular' will only use lazy for circular references. 'All' will set lazy for all properties referencing another schema.
+   * @default all
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/file.ts:
+   *     plugins:
+   *       - typescript
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       schema: yup
+   *       lazy: circular
+   * ```
+   */
+  lazyStrategy?: LazyStrategy;
+  /**
+   * @description Will separate the schema object from the object definition when set to true.
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   path/to/file.ts:
+   *     plugins:
+   *       - typescript
+   *       - graphql-codegen-validation-schema
+   *     config:
+   *       schema: yup
+   *       schemaObjectSeparate: true
+   * ```
+   */
+  separateSchemaObject?: boolean;
   /**
    * @description If defined, will use named imports from the specified module (defined in `importFrom`)
    * rather than individual imports for each type.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { MyZodSchemaVisitor } from './myzod/index.js';
 import { ValibotSchemaVisitor } from './valibot/index.js';
 import { YupSchemaVisitor } from './yup/index.js';
 import { ZodSchemaVisitor } from './zod/index.js';
+import { Zodv4SchemaVisitor } from './zodv4/index.js';
 
 export const plugin: PluginFunction<ValidationSchemaPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
@@ -32,6 +33,8 @@ export const plugin: PluginFunction<ValidationSchemaPluginConfig, Types.ComplexP
 function schemaVisitor(schema: GraphQLSchema, config: ValidationSchemaPluginConfig): SchemaVisitor {
   if (config?.schema === 'zod')
     return new ZodSchemaVisitor(schema, config);
+  else if (config?.schema === 'zodv4')
+    return new Zodv4SchemaVisitor(schema, config);
   else if (config?.schema === 'myzod')
     return new MyZodSchemaVisitor(schema, config);
   else if (config?.schema === 'valibot')

--- a/src/myzod/index.ts
+++ b/src/myzod/index.ts
@@ -312,6 +312,10 @@ export class MyZodSchemaVisitor extends BaseSchemaVisitor {
   ) {
     const typeName = visitor.prefixTypeNamespace(name);
     const shape = fields.map(field => generateFieldMyZodSchema(this.config, visitor, field, 2, this.circularTypes)).join(',\n');
+    const discriminatorField =
+      this.config.inputDiscriminator ?
+        `${indent(this.config.inputDiscriminator, this.config.validationSchemaExportType === 'const' ? 1 : 2)}: myzod.literal('${name}'),'),`
+        : ''
     const schemaObject = buildSchemaObject(name, discriminatorField, typeName, shape)
     switch (this.config.validationSchemaExportType) {
       case 'const':

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,62 @@
+import {
+    GraphQLSchema,
+    GraphQLNamedType,
+    getNamedType,
+    isObjectType,
+    isInputObjectType,
+    isInterfaceType,
+    isUnionType,
+    GraphQLType,
+} from 'graphql';
+
+export function findCircularTypes(schema: GraphQLSchema): Set<string> {
+    const circular = new Set<string>();
+    const visited = new Set<string>();
+    const stack = new Set<string>();
+
+    function visit(typeName: string): void {
+        if (stack.has(typeName)) {
+            circular.add(typeName);
+            return;
+        }
+
+        if (visited.has(typeName)) {
+            return;
+        }
+
+        visited.add(typeName);
+        stack.add(typeName);
+
+        const type: GraphQLNamedType | undefined = schema.getType(typeName);
+        if (!type) {
+            stack.delete(typeName);
+            return;
+        }
+
+        if (isUnionType(type)) {
+            for (const subtype of type.getTypes()) {
+                visit(subtype.name);
+            }
+        } else if (
+            isObjectType(type) ||
+            isInputObjectType(type) ||
+            isInterfaceType(type)
+        ) {
+            const fields = type.getFields();
+            for (const field of Object.values(fields)) {
+                const namedType = getNamedType(field.type as GraphQLType);
+                visit(namedType.name);
+            }
+        }
+
+        stack.delete(typeName);
+    }
+
+    for (const type of Object.values(schema.getTypeMap())) {
+        if (!type.name.startsWith('__')) {
+            visit(type.name);
+        }
+    }
+
+    return circular;
+}

--- a/src/valibot/index.ts
+++ b/src/valibot/index.ts
@@ -294,6 +294,10 @@ export class ValibotSchemaVisitor extends BaseSchemaVisitor {
   ) {
     const typeName = visitor.prefixTypeNamespace(name);
     const shape = fields.map(field => generateFieldValibotSchema(this.config, visitor, field, 2, this.circularTypes)).join(',\n');
+    const discriminatorField =
+      this.config.inputDiscriminator ?
+        `${indent(this.config.inputDiscriminator, this.config.validationSchemaExportType === 'const' ? 1 : 2)}: v.literal('${name}'),'),`
+        : ''
     const schemaObject = buildSchemaObject(name, discriminatorField, typeName, shape)
     switch (this.config.validationSchemaExportType) {
       case 'const':

--- a/src/yup/index.ts
+++ b/src/yup/index.ts
@@ -331,6 +331,10 @@ export class YupSchemaVisitor extends BaseSchemaVisitor {
   ) {
     const typeName = visitor.prefixTypeNamespace(name);
     const shape = shapeFields(fields, this.config, visitor);
+    const discriminatorField =
+      this.config.inputDiscriminator ?
+        `${indent(this.config.inputDiscriminator, this.config.validationSchemaExportType === 'const' ? 1 : 2)}: yup.string<'${name}'>(),'),`
+        : ''
     const schemaObject = buildSchemaObject(name, discriminatorField, typeName, shape)
     switch (this.config.validationSchemaExportType) {
       case 'const':

--- a/src/zodv4/index.ts
+++ b/src/zodv4/index.ts
@@ -1,0 +1,505 @@
+import type {
+    EnumTypeDefinitionNode,
+    FieldDefinitionNode,
+    GraphQLSchema,
+    InputObjectTypeDefinitionNode,
+    InputValueDefinitionNode,
+    InterfaceTypeDefinitionNode,
+    NameNode,
+    ObjectTypeDefinitionNode,
+    TypeNode,
+    UnionTypeDefinitionNode,
+} from 'graphql';
+
+import type { ValidationSchemaPluginConfig } from '../config.js';
+import type { Visitor } from '../visitor.js';
+import { resolveExternalModuleAndFn } from '@graphql-codegen/plugin-helpers';
+import { convertNameParts, DeclarationBlock, indent } from '@graphql-codegen/visitor-plugin-common';
+import {
+    Kind,
+} from 'graphql';
+import { buildApi, formatDirectiveConfig } from '../directive.js';
+import {
+    escapeGraphQLCharacters,
+    InterfaceTypeDefinitionBuilder,
+    isInput,
+    isListType,
+    isNamedType,
+    isNonNullType,
+    ObjectTypeDefinitionBuilder,
+} from '../graphql.js';
+import { BaseSchemaVisitor } from '../schema_visitor.js';
+import { findCircularTypes } from 'src/utils.js';
+
+export class Zodv4SchemaVisitor extends BaseSchemaVisitor {
+    private circularTypes: Set<string>
+    constructor(schema: GraphQLSchema, config: ValidationSchemaPluginConfig) {
+        super(schema, config);
+        this.circularTypes = findCircularTypes(schema)
+        this.config.lazyStrategy ??= 'all'
+    }
+
+    importValidationSchema(): string {
+        return `import { z } from 'zodv4'`;
+    }
+
+    initialEmit(): string {
+        return (
+            `\n${[
+                new DeclarationBlock({})
+                    .asKind('type')
+                    .withName('Properties<T>')
+                    .withContent(['Required<{', '  [K in keyof T]: z.ZodType<T[K], T[K]>;', '}>'].join('\n'))
+                    .string,
+                ...this.enumDeclarations,
+            ].join('\n')}`
+        );
+    }
+
+    get InputObjectTypeDefinition() {
+        return {
+            leave: (node: InputObjectTypeDefinitionNode) => {
+                const visitor = this.createVisitor('input');
+                const name = visitor.convertName(node.name.value);
+                this.importTypes.push(name);
+                return this.buildInputFields(node.fields ?? [], visitor, name);
+            },
+        };
+    }
+
+    get InterfaceTypeDefinition() {
+        return {
+            leave: InterfaceTypeDefinitionBuilder(this.config.withObjectType, (node: InterfaceTypeDefinitionNode) => {
+                const visitor = this.createVisitor('output');
+                const name = visitor.convertName(node.name.value);
+                const typeName = visitor.prefixTypeNamespace(name);
+                this.importTypes.push(name);
+
+                // Building schema for field arguments.
+                const argumentBlocks = this.buildTypeDefinitionArguments(node, visitor);
+                const appendArguments = argumentBlocks ? `\n${argumentBlocks}` : '';
+
+                // Building schema for fields.
+                const shape = node.fields?.map(field => generateFieldZodSchema(this.config, visitor, field, this.config.validationSchemaExportType === 'const' ? 1 : 2, this.circularTypes)).join(',\n');
+
+                // Building schema object for separateSchemaObject config option
+                const schemaObject = buildSchemaObject(name, '', typeName, shape)
+                switch (this.config.validationSchemaExportType) {
+                    case 'const':
+                        switch (this.config.separateSchemaObject) {
+                            case true:
+                                return (
+                                    schemaObject.string +
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('const')
+                                        .withName(`${name}Schema`)
+                                        .withContent(['z.object(', indent(schemaObject.name, 1), ')'].join('\n'))
+                                        .string + appendArguments
+                                )
+                            case false:
+                            default:
+                                return (
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('const')
+                                        .withName(`${name}Schema: z.ZodObject<Properties<${typeName}>>`)
+                                        .withContent([`z.object({`, shape, '})'].join('\n'))
+                                        .string + appendArguments
+                                );
+                        }
+
+                    case 'function':
+                    default:
+                        switch (this.config.separateSchemaObject) {
+                            case true:
+                                return (
+                                    schemaObject.string +
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('function')
+                                        .withName(`${name}Schema()`)
+                                        .withBlock([indent('return z.object('), indent(schemaObject.name, 1), indent(')')].join('\n'))
+                                        .string + appendArguments
+                                )
+                            case false:
+                            default:
+                                return (
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('function')
+                                        .withName(`${name}Schema(): z.ZodObject<Properties<${typeName}>>`)
+                                        .withBlock([indent('return z.object({'), shape, indent('})')].join('\n'))
+                                        .string + appendArguments
+                                );
+                        }
+                }
+            }),
+        };
+    }
+
+    get ObjectTypeDefinition() {
+        return {
+            leave: ObjectTypeDefinitionBuilder(this.config.withObjectType, (node: ObjectTypeDefinitionNode) => {
+                const visitor = this.createVisitor('output');
+                const name = visitor.convertName(node.name.value);
+                const typeName = visitor.prefixTypeNamespace(name);
+                this.importTypes.push(name);
+
+                // Building schema for field arguments.
+                const argumentBlocks = this.buildTypeDefinitionArguments(node, visitor);
+                const appendArguments = argumentBlocks ? `\n${argumentBlocks}` : '';
+
+                // Building schema for fields.
+                const shape = node.fields?.map(field => generateFieldZodSchema(this.config, visitor, field, this.config.validationSchemaExportType === 'const' ? 1 : 2, this.circularTypes)).join(',\n');
+
+                // Building schema object for separateSchemaObject config option
+                const schemaObject = buildSchemaObject(name, `__typename: z.literal('${name}').optional(),`, typeName, shape)
+                switch (this.config.validationSchemaExportType) {
+                    case 'const':
+                        switch (this.config.separateSchemaObject) {
+                            case true:
+                                return (
+                                    schemaObject.string +
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('const')
+                                        .withName(`${name}Schema`)
+                                        .withContent(
+                                            [
+                                                'z.object(',
+                                                indent(schemaObject.name, 1),
+                                                ')',
+                                            ].join('\n'),
+                                        )
+                                        .string + appendArguments
+                                )
+                            case false:
+                            default:
+                                return (
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('const')
+                                        .withName(`${name}Schema: z.ZodObject<Properties<${typeName}>>`)
+                                        .withContent(
+                                            [
+                                                'z.object({',
+                                                indent(`__typename: z.literal('${node.name.value}').optional(),`, 2),
+                                                shape,
+                                                '})',
+                                            ].join('\n'),
+                                        )
+                                        .string + appendArguments
+                                );
+                        }
+                    case 'function':
+                    default:
+                        switch (this.config.separateSchemaObject) {
+                            case true:
+                                return (
+                                    schemaObject.string +
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('function')
+                                        .withName(`${name}Schema()`)
+                                        .withBlock(
+                                            [
+                                                indent('return z.object('),
+                                                indent(schemaObject.name, 1),
+                                                indent(')'),
+                                            ].join('\n'),
+                                        )
+                                        .string + appendArguments
+                                )
+                            case false:
+                            default:
+                                return (
+                                    new DeclarationBlock({})
+                                        .export()
+                                        .asKind('function')
+                                        .withName(`${name}Schema(): z.ZodObject<Properties<${typeName}>>`)
+                                        .withBlock(
+                                            [
+                                                indent('return z.object({'),
+                                                indent(`__typename: z.literal('${node.name.value}').optional(),`, 2),
+                                                shape,
+                                                indent('})'),
+                                            ].join('\n'),
+                                        )
+                                        .string + appendArguments
+                                );
+                        }
+                }
+            }),
+        };
+    }
+
+    get EnumTypeDefinition() {
+        return {
+            leave: (node: EnumTypeDefinitionNode) => {
+                const visitor = this.createVisitor('both');
+                const enumname = visitor.convertName(node.name.value);
+                const enumTypeName = visitor.prefixTypeNamespace(enumname);
+                this.importTypes.push(enumname);
+
+                // hoist enum declarations
+                this.enumDeclarations.push(
+                    this.config.enumsAsTypes
+                        ? new DeclarationBlock({})
+                            .export()
+                            .asKind('const')
+                            .withName(`${enumname}Schema`)
+                            .withContent(`z.enum([${node.values?.map(enumOption => `'${enumOption.name.value}'`).join(', ')}])`)
+                            .string
+                        : new DeclarationBlock({})
+                            .export()
+                            .asKind('const')
+                            .withName(`${enumname}Schema`)
+                            .withContent(`z.enum(${enumTypeName})`)
+                            .string,
+                );
+            },
+        };
+    }
+
+    get UnionTypeDefinition() {
+        return {
+            leave: (node: UnionTypeDefinitionNode) => {
+                if (!node.types || !this.config.withObjectType)
+                    return;
+                const visitor = this.createVisitor('output');
+                const unionName = visitor.convertName(node.name.value);
+                const unionElements = node.types.map((t) => {
+                    const element = visitor.convertName(t.name.value);
+                    const typ = visitor.getType(t.name.value);
+                    if (typ?.astNode?.kind === 'EnumTypeDefinition')
+                        return `${element}Schema`;
+
+                    switch (this.config.validationSchemaExportType) {
+                        case 'const':
+                            return `${element}Schema`;
+                        case 'function':
+                        default:
+                            return `${element}Schema()`;
+                    }
+                }).join(', ');
+                const unionElementsCount = node.types.length ?? 0;
+
+                const union = unionElementsCount > 1 ? `z.union([${unionElements}])` : unionElements;
+
+                switch (this.config.validationSchemaExportType) {
+                    case 'const':
+                        return new DeclarationBlock({}).export().asKind('const').withName(`${unionName}Schema`).withContent(union).string;
+                    case 'function':
+                    default:
+                        return new DeclarationBlock({})
+                            .export()
+                            .asKind('function')
+                            .withName(`${unionName}Schema()`)
+                            .withBlock(indent(`return ${union}`))
+                            .string;
+                }
+            },
+        };
+    }
+
+    protected buildInputFields(
+        fields: readonly (FieldDefinitionNode | InputValueDefinitionNode)[],
+        visitor: Visitor,
+        name: string,
+    ) {
+        const typeName = visitor.prefixTypeNamespace(name);
+        const shape = fields.map(field => generateFieldZodSchema(this.config, visitor, field, this.config.validationSchemaExportType === 'const' ? 1 : 2, this.circularTypes)).join(',\n');
+
+        const discriminatorField =
+            this.config.inputDiscriminator ?
+                `${indent(this.config.inputDiscriminator, this.config.validationSchemaExportType === 'const' ? 1 : 2)}: z.literal('${name}'),`
+                : ''
+        const schemaObject = buildSchemaObject(name, discriminatorField, typeName, shape)
+        switch (this.config.validationSchemaExportType) {
+            case 'const':
+                switch (this.config.separateSchemaObject) {
+                    case true:
+                        return schemaObject.string + new DeclarationBlock({})
+                            .export()
+                            .asKind('const')
+                            .withName(`${name}Schema`)
+                            .withContent(['z.object(', indent(schemaObject.name, 1), ')'].join('\n'))
+                            .string;
+                    case false:
+                    default:
+                        return new DeclarationBlock({})
+                            .export()
+                            .asKind('const')
+                            .withName(`${name}Schema: z.ZodObject<Properties<${typeName}>>`)
+                            .withContent(['z.object({', shape, '})'].join('\n'))
+                            .string;
+                }
+            case 'function':
+            default:
+                switch (this.config.separateSchemaObject) {
+                    case true:
+                        return schemaObject.string + new DeclarationBlock({})
+                            .export()
+                            .asKind('function')
+                            .withName(`${name}Schema()`)
+                            .withBlock([indent('return z.object('), indent(schemaObject.name, 1), indent(')')].join('\n'))
+                            .string;
+
+                    case false:
+                    default:
+                        return new DeclarationBlock({})
+                            .export()
+                            .asKind('function')
+                            .withName(`${name}Schema(): z.ZodObject<Properties<${typeName}>>`)
+                            .withBlock([indent(`return z.object({`), shape, indent('})')].join('\n'))
+                            .string;
+                }
+        }
+    }
+}
+
+function generateFieldZodSchema(config: ValidationSchemaPluginConfig, visitor: Visitor, field: InputValueDefinitionNode | FieldDefinitionNode, indentCount: number, circularTypes: Set<string>): string {
+    const gen = generateFieldTypeZodSchema(config, visitor, field, field.type, circularTypes);
+    return indent(`${field.name.value}: ${maybeLazy(field.type, gen, config, circularTypes)}`, indentCount);
+}
+
+function generateFieldTypeZodSchema(config: ValidationSchemaPluginConfig, visitor: Visitor, field: InputValueDefinitionNode | FieldDefinitionNode, type: TypeNode, circularTypes: Set<string>, parentType?: TypeNode): string {
+    if (isListType(type)) {
+        const gen = generateFieldTypeZodSchema(config, visitor, field, type.type, circularTypes, type);
+        if (!isNonNullType(parentType)) {
+            const arrayGen = `z.array(${maybeLazy(type.type, gen, config, circularTypes)})`;
+            const maybeLazyGen = applyDirectives(config, field, arrayGen);
+            return `${maybeLazyGen}.nullish()`;
+        }
+        return `z.array(${maybeLazy(type.type, gen, config, circularTypes)})`;
+    }
+    if (isNonNullType(type)) {
+        const gen = generateFieldTypeZodSchema(config, visitor, field, type.type, circularTypes, type);
+        return maybeLazy(type.type, gen, config, circularTypes);
+    }
+    if (isNamedType(type)) {
+        const gen = generateNameNodeZodSchema(config, visitor, type.name);
+        if (isListType(parentType))
+            return `${gen}.nullable()`;
+
+        let appliedDirectivesGen = applyDirectives(config, field, gen);
+
+        if (field.kind === Kind.INPUT_VALUE_DEFINITION) {
+            const { defaultValue } = field;
+
+            if (defaultValue?.kind === Kind.INT || defaultValue?.kind === Kind.FLOAT || defaultValue?.kind === Kind.BOOLEAN)
+                appliedDirectivesGen = `${appliedDirectivesGen}.default(${defaultValue.value})`;
+
+            if (defaultValue?.kind === Kind.STRING || defaultValue?.kind === Kind.ENUM) {
+                if (config.useEnumTypeAsDefaultValue && defaultValue?.kind !== Kind.STRING) {
+                    let value = convertNameParts(defaultValue.value, resolveExternalModuleAndFn('change-case-all#pascalCase'), config.namingConvention?.transformUnderscore);
+
+                    if (config.namingConvention?.enumValues)
+                        value = convertNameParts(defaultValue.value, resolveExternalModuleAndFn(config.namingConvention?.enumValues), config.namingConvention?.transformUnderscore);
+
+                    appliedDirectivesGen = `${appliedDirectivesGen}.default(${type.name.value}.${value})`;
+                }
+                else {
+                    appliedDirectivesGen = `${appliedDirectivesGen}.default("${escapeGraphQLCharacters(defaultValue.value)}")`;
+                }
+            }
+        }
+
+        if (isNonNullType(parentType)) {
+            if (visitor.shouldEmitAsNotAllowEmptyString(type.name.value))
+                return `${appliedDirectivesGen}.min(1)`;
+
+            return appliedDirectivesGen;
+        }
+        if (isListType(parentType))
+            return `${appliedDirectivesGen}.nullable()`;
+
+        return `${appliedDirectivesGen}.nullish()`;
+    }
+    console.warn('unhandled type:', type);
+    return '';
+}
+
+function applyDirectives(config: ValidationSchemaPluginConfig, field: InputValueDefinitionNode | FieldDefinitionNode, gen: string): string {
+    if (config.directives && field.directives) {
+        const formatted = formatDirectiveConfig(config.directives);
+        return gen + buildApi(formatted, field.directives);
+    }
+    return gen;
+}
+
+function generateNameNodeZodSchema(config: ValidationSchemaPluginConfig, visitor: Visitor, node: NameNode): string {
+    const converter = visitor.getNameNodeConverter(node);
+
+    switch (converter?.targetKind) {
+        case 'InterfaceTypeDefinition':
+        case 'InputObjectTypeDefinition':
+        case 'ObjectTypeDefinition':
+        case 'UnionTypeDefinition':
+            // using switch-case rather than if-else to allow for future expansion
+            switch (config.validationSchemaExportType) {
+                case 'const':
+                    return `${converter.convertName()}Schema`;
+                case 'function':
+                default:
+                    return `${converter.convertName()}Schema()`;
+            }
+        case 'EnumTypeDefinition':
+            return `${converter.convertName()}Schema`;
+        case 'ScalarTypeDefinition':
+            return zod4Scalar(config, visitor, node.value);
+        default:
+            if (converter?.targetKind)
+                console.warn('Unknown targetKind', converter?.targetKind);
+
+            return zod4Scalar(config, visitor, node.value);
+    }
+}
+
+function maybeLazy(type: TypeNode, schema: string, config: ValidationSchemaPluginConfig, circularTypes: Set<string>) {
+    if (isNamedType(type)) {
+        const typeName = type.name.value
+
+        if (config.lazyStrategy === 'all' && isInput(typeName)) {
+            return `z.lazy(() => ${schema})`
+        }
+
+        if (config.lazyStrategy === 'circular' && circularTypes.has(typeName)) {
+            return `z.lazy(() => ${schema})`
+        }
+    }
+
+    return schema
+}
+
+function zod4Scalar(config: ValidationSchemaPluginConfig, visitor: Visitor, scalarName: string): string {
+    if (config.scalarSchemas?.[scalarName])
+        return config.scalarSchemas[scalarName];
+
+    const tsType = visitor.getScalarType(scalarName);
+    switch (tsType) {
+        case 'string':
+            return `z.string()`;
+        case 'number':
+            return `z.number()`;
+        case 'boolean':
+            return `z.boolean()`;
+    }
+
+    if (config.defaultScalarTypeSchema) {
+        return config.defaultScalarTypeSchema;
+    }
+
+    console.warn('unhandled scalar name:', scalarName);
+    return 'z.any()';
+}
+
+function buildSchemaObject(name: string, discriminator: string, typeName: string, shape: string | undefined) {
+    const objectName = name.charAt(0).toLowerCase() + name.slice(1) + 'SchemaObject'
+    return {
+        string: `export const ${objectName}: Properties<${typeName}> = {\n${discriminator}\n${shape}\n}\n\n`,
+        name: objectName,
+    }
+}
+


### PR DESCRIPTION
lazyStrategy - 'all' is current functionality, 'circular' is for truly circular references found by the util function

separateSchemaObject - defines the object outside of the schema vs inline

zodv4 - updated nativeEnum to enum, uses z.any() for any vs custom function, and updated the Properties type definition

inputDiscriminator - user can specify a discriminator key for input types and it will create it based off the type name