### PR TITLE
fix(zod): add explicit type annotations to enum schemas for isolatedDeclarations

### DIFF
--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -192,13 +192,13 @@ export class ZodSchemaVisitor extends BaseSchemaVisitor {
             ? new DeclarationBlock({})
               .export()
               .asKind('const')
-              .withName(`${enumname}Schema`)
+              .withName(`${enumname}Schema: z.ZodEnum<{ ${node.values?.map(enumOption => `${enumOption.name.value}: "${enumOption.name.value}"`).join('; ')} }>`)
               .withContent(`z.enum([${node.values?.map(enumOption => `'${enumOption.name.value}'`).join(', ')}])`)
               .string
             : new DeclarationBlock({})
               .export()
               .asKind('const')
-              .withName(`${enumname}Schema`)
+              .withName(`${enumname}Schema: z.ZodEnum<typeof ${enumTypeName}>`)
               .withContent(`z.nativeEnum(${enumTypeName})`)
               .string,
         );

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -227,7 +227,7 @@ describe('zod', () => {
     const result = await plugin(schema, [], { schema: 'zod', scalars }, {});
     expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
       "
-      export const PageTypeSchema = z.nativeEnum(PageType);
+      export const PageTypeSchema: z.ZodEnum<typeof PageType> = z.nativeEnum(PageType);
 
       export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
         return z.object({
@@ -252,7 +252,7 @@ describe('zod', () => {
     const result = await plugin(schema, [], { schema: 'zod', scalars, importFrom: './', schemaNamespacedImportName: 't' }, {});
     expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
       "
-      export const PageTypeSchema = z.nativeEnum(t.PageType);
+      export const PageTypeSchema: z.ZodEnum<typeof t.PageType> = z.nativeEnum(t.PageType);
 
       export function PageInputSchema(): z.ZodObject<Properties<t.PageInput>> {
         return z.object({
@@ -281,7 +281,7 @@ describe('zod', () => {
     const result = await plugin(schema, [], { schema: 'zod', scalars }, {});
     expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
       "
-      export const HttpMethodSchema = z.nativeEnum(HttpMethod);
+      export const HttpMethodSchema: z.ZodEnum<typeof HttpMethod> = z.nativeEnum(HttpMethod);
 
       export function HttpInputSchema(): z.ZodObject<Properties<HttpInput>> {
         return z.object({
@@ -443,7 +443,7 @@ describe('zod', () => {
     );
     expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
       "
-      export const PageTypeSchema = z.enum(['PUBLIC', 'BASIC_AUTH']);
+      export const PageTypeSchema: z.ZodEnum<{ PUBLIC: "PUBLIC"; BASIC_AUTH: "BASIC_AUTH" }> = z.enum(['PUBLIC', 'BASIC_AUTH']);
       "
     `)
   });
@@ -468,7 +468,7 @@ describe('zod', () => {
     );
     expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
       "
-      export const PageTypeSchema = z.enum(['PUBLIC', 'BASIC_AUTH']);
+      export const PageTypeSchema: z.ZodEnum<{ PUBLIC: "PUBLIC"; BASIC_AUTH: "BASIC_AUTH" }> = z.enum(['PUBLIC', 'BASIC_AUTH']);
       "
     `)
   });
@@ -711,7 +711,7 @@ describe('zod', () => {
       },
     );
 
-    expect(result.content).toContain('export const PageTypeSchema = z.nativeEnum(PageType)');
+    expect(result.content).toContain('export const PageTypeSchema: z.ZodEnum<typeof PageType> = z.nativeEnum(PageType)');
     expect(result.content).toContain('export function PageInputSchema(): z.ZodObject<Properties<PageInput>>');
 
     expect(result.content).toContain('pageType: PageTypeSchema.default(PageType.Public)');
@@ -747,7 +747,7 @@ describe('zod', () => {
       },
     );
 
-    expect(result.content).toContain('export const PageTypeSchema = z.nativeEnum(PageType)');
+    expect(result.content).toContain('export const PageTypeSchema: z.ZodEnum<typeof PageType> = z.nativeEnum(PageType)');
     expect(result.content).toContain('export function PageInputSchema(): z.ZodObject<Properties<PageInput>>');
 
     expect(result.content).toContain('pageType: PageTypeSchema.default(PageType.Basic_Auth)');
@@ -786,7 +786,7 @@ describe('zod', () => {
       },
     );
 
-    expect(result.content).toContain('export const PageTypeSchema = z.nativeEnum(PageType)');
+    expect(result.content).toContain('export const PageTypeSchema: z.ZodEnum<typeof PageType> = z.nativeEnum(PageType)');
     expect(result.content).toContain('export function PageInputSchema(): z.ZodObject<Properties<PageInput>>');
 
     expect(result.content).toContain('pageType: PageTypeSchema.default(PageType.BasicAuth)');
@@ -823,7 +823,7 @@ describe('zod', () => {
 
     expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
       "
-      export const PageTypeSchema = z.nativeEnum(PageType);
+      export const PageTypeSchema: z.ZodEnum<typeof PageType> = z.nativeEnum(PageType);
 
       export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
         return z.object({
@@ -1369,9 +1369,9 @@ describe('zod', () => {
 
       expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
         "
-        export const PageTypeSchema = z.nativeEnum(PageType);
+        export const PageTypeSchema: z.ZodEnum<typeof PageType> = z.nativeEnum(PageType);
 
-        export const MethodTypeSchema = z.nativeEnum(MethodType);
+        export const MethodTypeSchema: z.ZodEnum<typeof MethodType> = z.nativeEnum(MethodType);
 
         export function AnyTypeSchema() {
           return z.union([PageTypeSchema, MethodTypeSchema])
@@ -1787,7 +1787,7 @@ describe('zod', () => {
     );
     expect(removedInitialEmitValue(result.content)).toMatchInlineSnapshot(`
       "
-      export const TestSchema = z.nativeEnum(Test);
+      export const TestSchema: z.ZodEnum<typeof Test> = z.nativeEnum(Test);
 
       export function QueryInputSchema(): z.ZodObject<Properties<QueryInput>> {
         return z.object({


### PR DESCRIPTION
## Summary
This PR fixes #1187 by adding explicit type annotations to generated Zod enum schemas to make them compatible with TypeScript's `isolatedDeclarations` compiler option.

## Changes
- Added `z.ZodEnum<typeof EnumType>` type annotation for regular enums using `z.nativeEnum()`
- Added `z.ZodEnum<{ VALUE: "VALUE"; ... }>` type annotation for `enumsAsTypes` using `z.enum()`

## Example
**Before (causes TS9023 error):**
```typescript
export const StatusSchema = z.nativeEnum(Status);
```

**After (works with isolatedDeclarations):**
```typescript
export const StatusSchema: z.ZodEnum<typeof Status> = z.nativeEnum(Status);
```

## Test plan
- [x] All existing tests pass (264 tests)
- [x] Updated test expectations to match new type annotations
- [x] Verified the generated code includes proper type annotations

Fixes #1187

🤖 Generated with [Claude Code](https://claude.ai/code)